### PR TITLE
chore(build): 调整 build 的参数顺序

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "build": "rimraf dist && pnpm build:native && pnpm typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "pnpm build && electron-builder --dir --config electron-builder.config.ts",
-    "build:win": "pnpm build && tsx scripts/gen-license.ts && electron-builder --win --config electron-builder.config.ts",
-    "build:mac": "pnpm build && electron-builder --mac --config electron-builder.config.ts",
-    "build:linux": "pnpm build && electron-builder --linux --config electron-builder.config.ts"
+    "build:win": "pnpm build && tsx scripts/gen-license.ts && electron-builder --config electron-builder.config.ts --win",
+    "build:mac": "pnpm build && electron-builder --config electron-builder.config.ts --mac",
+    "build:linux": "pnpm build && electron-builder --config electron-builder.config.ts --linux"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",


### PR DESCRIPTION
`electron-builder` 可以像 `electron-builder --linux deb tar.gz` 或 `electron-builder --win nsis` 这样指定目标

将平台参数置于末尾，这样可以直接 `pnpm build:<platform> <target>`，更方便