### PR TITLE
fix: 修正 appId/desktopName 反向域名为 top.imsyy

### DIFF
--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -1,7 +1,7 @@
 import type { Configuration } from "electron-builder";
 
 const config: Configuration = {
-  appId: "com.imsyy.splayer-next",
+  appId: "top.imsyy.splayer-next",
   productName: "SPlayer-Next",
   copyright: "Copyright © imsyy 2025",
   directories: { buildResources: "public" },
@@ -55,7 +55,7 @@ const config: Configuration = {
   },
   nsis: {
     oneClick: false,
-    guid: "com.imsyy.splayer-next",
+    guid: "top.imsyy.splayer-next",
     installerIcon: "public/icons/favicon.ico",
     uninstallerIcon: "public/icons/favicon.ico",
     artifactName: "${productName}-${version}-${arch}-setup.${ext}",

--- a/electron/main/core/index.ts
+++ b/electron/main/core/index.ts
@@ -81,7 +81,7 @@ export const initApp = (): void => {
   registerCacheScheme();
   // 其他初始化
   app.whenReady().then(() => {
-    electronApp.setAppUserModelId("com.imsyy.splayer-next");
+    electronApp.setAppUserModelId("top.imsyy.splayer-next");
     // 注册 cache:// 协议处理
     handleCacheProtocol();
     app.on("browser-window-created", (_, window) => {

--- a/native/media-ctrl/src/sys_media/linux.rs
+++ b/native/media-ctrl/src/sys_media/linux.rs
@@ -256,7 +256,7 @@ async fn run_mpris_loop(mut rx: UnboundedReceiver<MprisCommand>) -> Result<()> {
         .maximum_rate(2.0)
         .playback_status(MprisPlaybackStatus::Stopped)
         .identity("SPlayer-Next")
-        .desktop_entry("com.imsyy.splayer-next")
+        .desktop_entry("top.imsyy.splayer_next")
         .build()
         .await
         .map_err(|e| anyhow::anyhow!("MPRIS 初始化失败: {e}"))?;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splayer-next",
   "productName": "SPlayer-Next",
-  "desktopName": "com.imsyy.splayer-next",
+  "desktopName": "top.imsyy.splayer_next",
   "version": "1.0.0",
   "description": "A modern cross-platform music player built with Electron, Vue 3, and TypeScript",
   "type": "module",


### PR DESCRIPTION
## 背景

修正 #33：项目当前使用 `com.imsyy.splayer-next` 作为 appId / desktopName，但 `imsyy.com` 域名不受维护者控制。趁正式发布前改为受控的 `top.imsyy` 反向域名。

## 改动

| 文件 | 字段 | 改为 |
| --- | --- | --- |
| `electron-builder.config.ts` | `appId` | `top.imsyy.splayer-next`（保留连字符） |
| `electron-builder.config.ts` | `nsis.guid` | `top.imsyy.splayer-next`（原镜像 appId，一并清掉 com.imsyy 残留） |
| `electron/main/core/index.ts` | `setAppUserModelId` | `top.imsyy.splayer-next`（Windows AUMID 必须等于 appId） |
| `package.json` | `desktopName` | `top.imsyy.splayer_next`（下划线） |
| `native/media-ctrl/src/sys_media/linux.rs` | MPRIS `desktop_entry` | `top.imsyy.splayer_next`（必须等于 .desktop 文件名） |

## 为什么 desktopName 用下划线、appId 用连字符

按 #33 的建议：部分反向域名用法（D-Bus 对象路径 / 接口名、Flatpak App ID）禁止连字符，故 `desktopName` 用 `_`；`appId` 仍保留 `-`。

经 electron-builder（app-builder-lib 26.15.3）源码确认其一致性：`syncDesktopName: true` 时，`.desktop` 文件名与 Electron 的 Linux app_id / `StartupWMClass` 均派生自 `package.json.desktopName`。因此 MPRIS 的 `desktop_entry` 必须同步改为 `top.imsyy.splayer_next`，否则 Linux 媒体控件无法关联应用图标。

## 有意保留的 `splayer-next`（连字符）

这些不是反向域名标识，不受相关限制，未改动：更新器缓存目录名、流媒体 deviceId、MPRIS 总线名后缀（D-Bus 总线名允许连字符）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)