### PR TITLE
feat(netease): 添加网易云音乐听歌打卡功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/.vitepress/dist
 skills-lock.json
 *.log*
 .vscode/settings.json
+.idea
 
 # Rust build artifacts
 **/target

--- a/electron/main/apis/netease/core/config.ts
+++ b/electron/main/apis/netease/core/config.ts
@@ -22,6 +22,10 @@ MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgtQn2JZ34ZC28NWYpAUd98iZ37BUrX/aKzmFbt7cl
 export const DOMAIN = "https://music.163.com";
 /** 客户端接口域名（api/eapi） */
 export const API_DOMAIN = "https://interface.music.163.com";
+/** 客户端日志域名 */
+export const CLIENT_LOG_DOMAIN = "https://clientlog.music.163.com";
+/** NCBL 加密日志域名 */
+export const CLIENT_LOG3_DOMAIN = "https://clientlog3.music.163.com";
 /** 是否默认对响应体做 eapi 加密（e_r） */
 export const ENCRYPT_RESPONSE = false;
 

--- a/electron/main/apis/netease/core/config.ts
+++ b/electron/main/apis/netease/core/config.ts
@@ -56,6 +56,12 @@ export const OS_MAP = {
     osver: "16.2",
     channel: "distribution",
   },
+  osx: {
+    os: "osx",
+    appver: "3.1.10.5100",
+    osver: "15.5",
+    channel: "netease",
+  },
 } as const;
 
 /** 不同加密方式 + 设备类型下的 User-Agent */

--- a/electron/main/apis/netease/core/ncbl.ts
+++ b/electron/main/apis/netease/core/ncbl.ts
@@ -1,0 +1,464 @@
+import { randomBytes, randomUUID as cryptoRandomUUID } from "node:crypto";
+import * as zlib from "node:zlib";
+import { CLIENT_LOG3_DOMAIN } from "./config";
+
+interface NeteaseLogRecord {
+  time: number;
+  action: string;
+  data: unknown;
+}
+
+interface NcblContext {
+  app: {
+    id: string;
+    urs: string;
+    pid: string;
+    nsm: string;
+    cid: string;
+    channel: string;
+    version: string;
+    versionCode: string;
+    buildCode: string;
+    buildType: string;
+    packageId: string;
+  };
+  device: {
+    id: string;
+    ti: string;
+    sign: string;
+    model: string;
+    nnid: string;
+    nuid: string;
+    csrf: string;
+    systemType: string;
+    systemVersion: string;
+  };
+  auth: {
+    token: string;
+    sessionId: string;
+    vipType: string;
+  };
+  startTime: number;
+  processId: number;
+}
+
+interface NcblSong {
+  id: number;
+  name: string;
+  artist: string;
+  bitrate: number;
+  level: string;
+  vip: boolean;
+  time: number;
+}
+
+interface NcblSource {
+  id: string;
+  type: string;
+  name: string;
+}
+
+interface UploadResult {
+  success: boolean;
+  fileName: string;
+  payload: Buffer;
+  respBody: Record<string, any>;
+}
+
+const SIGMA = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
+const RSA_N = 0xfd90bd466ff9bc8a3fec2fbcf263b90d5c564879fa5d7aab89b31c1d5cb4139dn;
+const RSA_E = 65537n;
+const MAGIC = Buffer.from("NCBL", "ascii");
+const NCBL_VERSION = 3;
+const HEADER_FIXED_LEN = 70;
+const META_BLOCK_TYPE = 0x4343;
+const DEFAULT_MAX_FRAME = 0x8000;
+const FIELD_SEP = "\x01";
+
+const rotl = (x: number, n: number): number => ((x << n) | (x >>> (32 - n))) >>> 0;
+
+const quarterRound = (s: Uint32Array, a: number, b: number, c: number, d: number): void => {
+  s[a] = (s[a] + s[b]) >>> 0;
+  s[d] ^= s[a];
+  s[d] = rotl(s[d], 16);
+  s[c] = (s[c] + s[d]) >>> 0;
+  s[b] ^= s[c];
+  s[b] = rotl(s[b], 12);
+  s[a] = (s[a] + s[b]) >>> 0;
+  s[d] ^= s[a];
+  s[d] = rotl(s[d], 8);
+  s[c] = (s[c] + s[d]) >>> 0;
+  s[b] ^= s[c];
+  s[b] = rotl(s[b], 7);
+};
+
+const chachaBlock = (key: Buffer, counter: number, nonce: Buffer): Buffer => {
+  const state = new Uint32Array(16);
+  state[0] = SIGMA[0];
+  state[1] = SIGMA[1];
+  state[2] = SIGMA[2];
+  state[3] = SIGMA[3];
+  for (let i = 0; i < 8; i++) state[4 + i] = key.readUInt32LE(i * 4);
+  state[12] = counter >>> 0;
+  state[13] = nonce.readUInt32LE(0);
+  state[14] = nonce.readUInt32LE(4);
+  state[15] = nonce.readUInt32LE(8);
+
+  const work = state.slice();
+  for (let i = 0; i < 10; i++) {
+    quarterRound(work, 0, 4, 8, 12);
+    quarterRound(work, 1, 5, 9, 13);
+    quarterRound(work, 2, 6, 10, 14);
+    quarterRound(work, 3, 7, 11, 15);
+    quarterRound(work, 0, 5, 10, 15);
+    quarterRound(work, 1, 6, 11, 12);
+    quarterRound(work, 2, 7, 8, 13);
+    quarterRound(work, 3, 4, 9, 14);
+  }
+
+  const out = Buffer.allocUnsafe(64);
+  for (let i = 0; i < 16; i++) out.writeUInt32LE((work[i] + state[i]) >>> 0, i * 4);
+  return out;
+};
+
+const chacha20 = (key: Buffer, counter: number, nonce: Buffer, data: Buffer): Buffer => {
+  const out = Buffer.allocUnsafe(data.length);
+  for (let off = 0; off < data.length; off += 64) {
+    const ks = chachaBlock(key, (counter + (off >>> 6)) >>> 0, nonce);
+    const end = Math.min(off + 64, data.length);
+    for (let i = off; i < end; i++) out[i] = data[i] ^ ks[i - off];
+  }
+  return out;
+};
+
+const beToBig = (buf: Buffer): bigint => {
+  let n = 0n;
+  for (const b of buf) n = (n << 8n) | BigInt(b);
+  return n;
+};
+
+const bigToBe = (n: bigint, len: number): Buffer => {
+  const out = Buffer.alloc(len);
+  for (let i = len - 1; i >= 0; i--) {
+    out[i] = Number(n & 0xffn);
+    n >>= 8n;
+  }
+  return out;
+};
+
+const modPow = (base: bigint, exp: bigint, mod: bigint): bigint => {
+  let result = 1n;
+  base %= mod;
+  while (exp > 0n) {
+    if (exp & 1n) result = (result * base) % mod;
+    base = (base * base) % mod;
+    exp >>= 1n;
+  }
+  return result;
+};
+
+export const rsaWrap = (keyA: Buffer): Buffer => bigToBe(modPow(beToBig(keyA), RSA_E, RSA_N), 32);
+
+const compressBody = (buf: Buffer): Buffer => {
+  const zstd = (zlib as unknown as { zstdCompressSync?: (input: Buffer) => Buffer })
+    .zstdCompressSync;
+  return zstd ? zstd(buf) : zlib.gzipSync(buf);
+};
+
+export const encryptNCBL = (meta: string | Buffer, body: string | Buffer): Buffer => {
+  const metaBuf = Buffer.isBuffer(meta) ? meta : Buffer.from(meta, "utf-8");
+  const bodyBuf = Buffer.isBuffer(body) ? body : Buffer.from(body, "utf-8");
+  const keyA = randomBytes(32);
+  if (keyA[0] >= 0xa3) keyA[0] = 0xa2;
+  const keyB = rsaWrap(keyA);
+  const uuid = randomBytes(16);
+  uuid[6] = (uuid[6] & 0x0f) | 0x40;
+  uuid[8] = (uuid[8] & 0x3f) | 0x80;
+  const nonce = uuid.subarray(0, 12);
+  const counter = uuid.readUInt32LE(12) >>> 2;
+  const baseSeq = randomBytes(2).readUInt16LE(0);
+
+  const metaCipher = chacha20(keyB, counter, nonce, metaBuf);
+  const metaHead = Buffer.allocUnsafe(4);
+  metaHead.writeUInt16LE(META_BLOCK_TYPE, 0);
+  metaHead.writeUInt16LE(metaCipher.length, 2);
+  const metaBlock = Buffer.concat([metaHead, metaCipher]);
+  const headerLen = HEADER_FIXED_LEN + metaBlock.length;
+  const compressed = compressBody(bodyBuf);
+
+  const frames: Buffer[] = [];
+  let seq = baseSeq;
+  for (let off = 0; off < compressed.length || off === 0; off += DEFAULT_MAX_FRAME) {
+    const slice = compressed.subarray(off, off + DEFAULT_MAX_FRAME);
+    const cipher = chacha20(keyA, counter, nonce, slice);
+    const head = Buffer.allocUnsafe(6);
+    head.writeUInt16LE(cipher.length, 0);
+    head.writeUInt32LE(seq >>> 0, 2);
+    frames.push(head, cipher);
+    seq++;
+    if (compressed.length === 0) break;
+  }
+
+  const trailing = Buffer.concat(frames);
+  const frameCount = seq - baseSeq;
+  const header = Buffer.alloc(HEADER_FIXED_LEN);
+  MAGIC.copy(header, 0);
+  header.writeUInt32LE(NCBL_VERSION, 4);
+  header.writeUInt16LE(headerLen, 8);
+  uuid.copy(header, 10);
+  keyB.copy(header, 26);
+  header.writeUInt32LE(baseSeq >>> 0, 58);
+  header.writeUInt32LE((baseSeq + frameCount - 1) >>> 0, 62);
+  header.writeUInt32LE(trailing.length, 66);
+  return Buffer.concat([header, metaBlock, trailing]);
+};
+
+const buildRecord = ({ time, action, data }: NeteaseLogRecord): string => {
+  const json = typeof data === "string" ? data : JSON.stringify(data);
+  return [time, action, json].join(FIELD_SEP);
+};
+
+export const buildRecords = (records: NeteaseLogRecord[]): string =>
+  records.map(buildRecord).join("");
+
+export const buildPlv = (
+  ctx: NcblContext,
+  song: NcblSong,
+  source: NcblSource,
+): Record<string, unknown> => {
+  const now = Date.now();
+  return {
+    mode: "circulation",
+    download: 0,
+    alg: "",
+    status: "front",
+    id: String(song.id),
+    bitrate: song.bitrate,
+    type: "song",
+    is_listentogether: 0,
+    source: source.name,
+    is_heart: 0,
+    resource_ratio: "",
+    resource_time: song.time,
+    musiceffect_id: "",
+    app_mode: 2,
+    bitrate_level: song.level,
+    _addrefer: `[F:63][${now}#933#${ctx.app.version}#${ctx.app.versionCode}#c9156c3][e][2][23][cell_pc_songlist_song:2|page_pc_songlist_songflow|page_mine_like_music][${song.id}:song:x:x|:::|${source.id}:list::]`,
+    _multirefers: [
+      "[F:26][s][18][_ai]",
+      "[F:26][s][12][_ai]",
+      `[F:63][${now}#933#${ctx.app.version}#${ctx.app.versionCode}#c9156c3][e][2][8][cell_pc_main_tab_entrance:6|page_pc_main_tab][我喜欢的音乐:spm::|:::]`,
+      "[F:26][s][5][_ai]",
+      "[F:26][s][0][_ai]",
+    ],
+    vipType: ctx.auth.vipType,
+    fee: 1,
+    file: 4,
+    rightSource: 0,
+    sourceId: source.id,
+    sourcetype: source.type,
+    libra_abt: "",
+    channel: ctx.app.channel,
+    curStartChannel: "",
+  };
+};
+
+export const buildPld = (
+  ctx: NcblContext,
+  song: NcblSong,
+  source: NcblSource,
+  played: number,
+): Record<string, unknown> => {
+  const now = Date.now();
+  return {
+    mode: "circulation",
+    download: 0,
+    alg: "",
+    status: "front",
+    id: String(song.id),
+    time: played,
+    type: "song",
+    is_listentogether: 0,
+    source: source.name,
+    is_heart: 0,
+    realtime: played,
+    resource_ratio: "",
+    resource_time: song.time,
+    musiceffect_id: "1001",
+    app_mode: 1,
+    lyriceffect: "default",
+    displayMode: "classic",
+    bitrate: song.bitrate,
+    bitrate_level: song.level,
+    _addrefer: `[F:63][${now}#616#${ctx.app.version}#${ctx.app.versionCode}#c9156c3][e][2][92][btn_pc_cover_play|cell_pc_songlist_song:6|page_pc_songlist_songflow|page_mine_like_music][:::|${song.id}:song:x:x|:::|${source.id}:list::]`,
+    _multirefers: [
+      "[F:26][s][87][_ai]",
+      "[F:26][s][81][_ai]",
+      "[F:26][s][75][_ai]",
+      "[F:26][s][69][_ai]",
+      "[F:26][s][63][_ai]",
+    ],
+    vipType: ctx.auth.vipType,
+    fee: 8,
+    file: 4,
+    rightSource: 0,
+    sourceId: source.id,
+    sourcetype: source.type,
+    end: "interrupt",
+    libra_abt: "",
+    channel: ctx.app.channel,
+    curStartChannel: "",
+  };
+};
+
+export const parseCookie = (cookie: unknown): Record<string, string> => {
+  if (cookie && typeof cookie === "object") return cookie as Record<string, string>;
+  if (typeof cookie !== "string") return {};
+  const obj: Record<string, string> = {};
+  for (const part of cookie.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx <= 0) continue;
+    const key = part.substring(0, idx).trim();
+    const val = part.substring(idx + 1).trim();
+    if (key) obj[key] = val;
+  }
+  return obj;
+};
+
+export const extractContext = (cookieObj: Record<string, string>): NcblContext => ({
+  app: {
+    id: cookieObj.appid || "",
+    urs: "",
+    pid: "",
+    nsm: cookieObj.WEVNSM || "1.0.0",
+    cid: cookieObj.WNMCID || `${randomBytes(3).toString("hex")}.${Date.now()}.01.0`,
+    channel: cookieObj.channel || "netease",
+    version: cookieObj.appver || "3.1.35",
+    versionCode: cookieObj.versioncode || "205293",
+    buildCode: cookieObj.buildver || "",
+    buildType: "release",
+    packageId: "",
+  },
+  device: {
+    id: cookieObj.deviceId || cookieObj.sDeviceId || "",
+    ti: cookieObj.NMTID || "",
+    sign: cookieObj.clientSign || "",
+    model: cookieObj.mode || cookieObj.mobilename || "",
+    nnid: cookieObj._ntes_nnid || ",",
+    nuid: cookieObj._ntes_nuid || "",
+    csrf: cookieObj.__csrf || "",
+    systemType: cookieObj.os || "pc",
+    systemVersion: cookieObj.osver || "Microsoft-Windows-10-Professional-build-19045-64bit",
+  },
+  auth: {
+    token: cookieObj.MUSIC_U || "",
+    sessionId: cookieObj["JSESSIONID-WYYY"] || "",
+    vipType: cookieObj.vipType || "",
+  },
+  startTime: Date.now(),
+  processId: Math.floor(Math.random() * 90000) + 10000,
+});
+
+const randomHexId = (): string => cryptoRandomUUID().replace(/-/g, "");
+
+export const buildMultipart = (
+  payload: Buffer,
+): { boundary: string; fileName: string; body: Buffer } => {
+  const boundary = randomHexId();
+  const fileName = `op_${Math.floor(Math.random() * 90000) + 10000}_0_${
+    Math.floor(Math.random() * 4294967295) + 1
+  }`;
+  const crlf = "\r\n";
+  const header = [
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="file"; filename="${fileName}"`,
+    "Content-Type: multipart/form-data",
+    "",
+    "",
+  ].join(crlf);
+  const footer = `${crlf}--${boundary}--${crlf}`;
+  return {
+    boundary,
+    fileName,
+    body: Buffer.concat([Buffer.from(header, "utf-8"), payload, Buffer.from(footer, "utf-8")]),
+  };
+};
+
+export const buildCookieStr = (ctx: NcblContext): string =>
+  [
+    `JSESSIONID-WYYY=${ctx.auth.sessionId}`,
+    `MUSIC_U=${ctx.auth.token}`,
+    `NMTID=${ctx.device.ti}`,
+    `WEVNSM=${ctx.app.nsm}`,
+    `WNMCID=${ctx.app.cid}`,
+    `__csrf=${ctx.device.csrf}`,
+    "__remember_me=true",
+    "_iuqxldmzr_=33",
+    `_ntes_nnid=${ctx.device.nnid}`,
+    `_ntes_nuid=${ctx.device.nuid}`,
+    `appver=${ctx.app.version}.${ctx.app.versionCode}`,
+    `channel=${ctx.app.channel}`,
+    `clientSign=${ctx.device.sign}`,
+    `deviceId=${ctx.device.id}`,
+    `mode=${ctx.device.model}`,
+    "ntes_kaola_ad=1",
+    `os=${ctx.device.systemType}`,
+    `osver=${ctx.device.systemVersion}`,
+  ].join("; ");
+
+export const buildMetaJson = (ctx: NcblContext): string =>
+  JSON.stringify({
+    "JSESSIONID-WYYY": ctx.auth.sessionId,
+    MUSIC_U: ctx.auth.token,
+    NMTID: ctx.device.ti,
+    WEVNSM: ctx.app.nsm,
+    WNMCID: ctx.app.cid,
+    __csrf: ctx.device.csrf,
+    _iuqxldmzr_: "33",
+    _ntes_nnid: ctx.device.nnid,
+    _ntes_nuid: ctx.device.nuid,
+    appver: `${ctx.app.version}.${ctx.app.versionCode}`,
+    channel: ctx.app.channel,
+    clientSign: ctx.device.sign,
+    deviceId: ctx.device.id,
+    mode: ctx.device.model,
+    ntes_kaola_ad: "1",
+    os: ctx.device.systemType,
+    osver: ctx.device.systemVersion,
+  });
+
+export const doUpload = async (
+  ctx: NcblContext,
+  metaJson: string,
+  body: string,
+  cookieStr: string,
+  label?: string,
+): Promise<UploadResult> => {
+  void label;
+  const payload = encryptNCBL(metaJson, body);
+  const multipart = buildMultipart(payload);
+  const resp = await fetch(`${CLIENT_LOG3_DOMAIN}/api/clientlog/encrypt/upload?multiupload=true`, {
+    method: "POST",
+    headers: {
+      "Content-Type": `multipart/form-data; boundary=${multipart.boundary}`,
+      Referer: "https://music.163.com/di",
+      "User-Agent": `Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/91.0.4472.164 NeteaseMusicDesktop/${ctx.app.version}`,
+      "Accept-Encoding": "gzip,deflate",
+      "Accept-Language": "zh-CN,zh;q=0.8",
+      Cookie: cookieStr,
+    },
+    body: new Uint8Array(multipart.body),
+    signal: AbortSignal.timeout(15000),
+  });
+
+  const text = await resp.text();
+  let respBody: Record<string, any>;
+  try {
+    respBody = JSON.parse(text) as Record<string, any>;
+  } catch {
+    respBody = { code: resp.status, raw: text };
+  }
+  const success =
+    respBody?.code === 200 && respBody?.data?.successfiles?.includes?.(multipart.fileName);
+  return { success, fileName: multipart.fileName, payload, respBody };
+};

--- a/electron/main/apis/netease/core/ncbl.ts
+++ b/electron/main/apis/netease/core/ncbl.ts
@@ -162,7 +162,9 @@ export const rsaWrap = (keyA: Buffer): Buffer => bigToBe(modPow(beToBig(keyA), R
 const compressBody = (buf: Buffer): Buffer => {
   const zstd = (zlib as unknown as { zstdCompressSync?: (input: Buffer) => Buffer })
     .zstdCompressSync;
-  return zstd ? zstd(buf) : zlib.gzipSync(buf);
+  // NCBL v3 头不带压缩标识,服务端固定按 zstd 解;缺 zstd 时直接报错,不能塞 gzip 让服务端解不开
+  if (!zstd) throw new Error("当前运行时不支持 zstd,无法进行 NCBL 上报");
+  return zstd(buf);
 };
 
 export const encryptNCBL = (meta: string | Buffer, body: string | Buffer): Buffer => {
@@ -432,9 +434,7 @@ export const doUpload = async (
   metaJson: string,
   body: string,
   cookieStr: string,
-  label?: string,
 ): Promise<UploadResult> => {
-  void label;
   const payload = encryptNCBL(metaJson, body);
   const multipart = buildMultipart(payload);
   const resp = await fetch(`${CLIENT_LOG3_DOMAIN}/api/clientlog/encrypt/upload?multiupload=true`, {

--- a/electron/main/apis/netease/core/request.ts
+++ b/electron/main/apis/netease/core/request.ts
@@ -66,6 +66,10 @@ interface NeteaseBody {
 /** weapi 专用 CSRF：从 cookie 中取 __csrf */
 const csrfFrom = (cookie: Record<string, string>): string => cookie["__csrf"] || "";
 
+/** macOS 客户端日志接口需要桌面浏览器 UA */
+const OSX_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
 /** 生成 WNMCID（进程级常量）：6 位小写字母.时间戳.01.0 */
 const WNMCID = (() => {
   const chars = "abcdefghijklmnopqrstuvwxyz";
@@ -200,7 +204,8 @@ export const createRequest = async (
       if (cookie.MUSIC_U) header.MUSIC_U = cookie.MUSIC_U;
       if (cookie.MUSIC_A) header.MUSIC_A = cookie.MUSIC_A;
       headers["Cookie"] = cookieObjToString(header);
-      headers["User-Agent"] = options.ua || chooseUserAgent("api", "iphone");
+      headers["User-Agent"] =
+        options.ua || (cookie.os === "osx" ? OSX_USER_AGENT : chooseUserAgent("api", "iphone"));
 
       if (crypto === "eapi") {
         (data as Record<string, unknown>).header = header;

--- a/electron/main/apis/netease/index.ts
+++ b/electron/main/apis/netease/index.ts
@@ -38,6 +38,7 @@ const NON_CACHEABLE: ReadonlySet<string> = new Set([
   "song_url",
   "song_download_url",
   "scrobble",
+  "scrobble_v1",
   "like",
   "playlist_create",
   "playlist_delete",

--- a/electron/main/apis/netease/index.ts
+++ b/electron/main/apis/netease/index.ts
@@ -37,6 +37,7 @@ const SESSION_MUTATING: ReadonlySet<string> = new Set([
 const NON_CACHEABLE: ReadonlySet<string> = new Set([
   "song_url",
   "song_download_url",
+  "scrobble",
   "like",
   "playlist_create",
   "playlist_delete",

--- a/electron/main/apis/netease/modules/index.ts
+++ b/electron/main/apis/netease/modules/index.ts
@@ -56,6 +56,7 @@ import song_download_url from "./song_download_url";
 import playmode_intelligence from "./playmode_intelligence";
 import personal_fm from "./personal_fm";
 import fm_trash from "./fm_trash";
+import scrobble from "./scrobble";
 
 // 每日推荐 / 发现
 import recommend_songs from "./recommend_songs";
@@ -135,6 +136,7 @@ export const modules: Record<string, NeteaseModule> = {
   playmode_intelligence,
   personal_fm,
   fm_trash,
+  scrobble,
 
   recommend_songs,
   personalized,

--- a/electron/main/apis/netease/modules/index.ts
+++ b/electron/main/apis/netease/modules/index.ts
@@ -57,6 +57,7 @@ import playmode_intelligence from "./playmode_intelligence";
 import personal_fm from "./personal_fm";
 import fm_trash from "./fm_trash";
 import scrobble from "./scrobble";
+import scrobble_v1 from "./scrobble_v1";
 
 // 每日推荐 / 发现
 import recommend_songs from "./recommend_songs";
@@ -137,6 +138,7 @@ export const modules: Record<string, NeteaseModule> = {
   personal_fm,
   fm_trash,
   scrobble,
+  scrobble_v1,
 
   recommend_songs,
   personalized,

--- a/electron/main/apis/netease/modules/scrobble.ts
+++ b/electron/main/apis/netease/modules/scrobble.ts
@@ -1,0 +1,33 @@
+/**
+ * 听歌打卡
+ *
+ * 更新网易云听歌排行数据，需要登录态。
+ */
+
+import { createOption } from "../core/option";
+import type { NeteaseModule } from "../core/types";
+
+const scrobble: NeteaseModule = (query, request) => {
+  const data = {
+    logs: JSON.stringify([
+      {
+        action: "play",
+        json: {
+          download: 0,
+          end: "playend",
+          id: query.id,
+          sourceId: query.sourceid,
+          time: query.time,
+          type: "song",
+          wifi: 0,
+          source: "list",
+          mainsite: 1,
+          content: "",
+        },
+      },
+    ]),
+  };
+  return request("/api/feedback/weblog", data, createOption(query, "weapi"));
+};
+
+export default scrobble;

--- a/electron/main/apis/netease/modules/scrobble.ts
+++ b/electron/main/apis/netease/modules/scrobble.ts
@@ -7,8 +7,33 @@
 import { createOption } from "../core/option";
 import type { NeteaseModule } from "../core/types";
 
-const scrobble: NeteaseModule = (query, request) => {
-  const data = {
+const scrobble: NeteaseModule = async (query, request) => {
+  if (typeof query.cookie === "object" && query.cookie) {
+    query.cookie = { os: "osx", ...query.cookie };
+  } else if (typeof query.cookie === "string") {
+    query.cookie = query.cookie.includes("os=")
+      ? query.cookie.replace(/os=[^;]+/g, "os=osx")
+      : `${query.cookie}; os=osx`;
+  } else {
+    query.cookie = "os=osx";
+  }
+
+  const startplayData = {
+    logs: JSON.stringify([
+      {
+        action: "startplay",
+        json: {
+          id: query.id,
+          type: "song",
+          mainsite: "1",
+          mainsiteWeb: "1",
+          content: `id=${query.sourceid}`,
+        },
+      },
+    ]),
+  };
+
+  const playData = {
     logs: JSON.stringify([
       {
         action: "play",
@@ -21,13 +46,32 @@ const scrobble: NeteaseModule = (query, request) => {
           type: "song",
           wifi: 0,
           source: "list",
-          mainsite: 1,
-          content: "",
+          mainsite: "1",
+          mainsiteWeb: "1",
+          content: `id=${query.sourceid}`,
         },
       },
     ]),
   };
-  return request("/api/feedback/weblog", data, createOption(query, "weapi"));
+
+  const option = createOption(query, "eapi");
+  option.domain = "https://clientlog.music.163.com";
+
+  const startplay = await request("/api/feedback/weblog", startplayData, option);
+  const play = await request("/api/feedback/weblog", playData, option);
+
+  return {
+    status: 200,
+    body: {
+      code: 200,
+      data: "success",
+      details: {
+        startplay: startplay.body,
+        play: play.body,
+      },
+    },
+    cookie: [],
+  };
 };
 
 export default scrobble;

--- a/electron/main/apis/netease/modules/scrobble.ts
+++ b/electron/main/apis/netease/modules/scrobble.ts
@@ -5,6 +5,7 @@
  */
 
 import { createOption } from "../core/option";
+import { CLIENT_LOG_DOMAIN } from "../core/config";
 import type { NeteaseModule } from "../core/types";
 
 const scrobble: NeteaseModule = async (query, request) => {
@@ -55,7 +56,7 @@ const scrobble: NeteaseModule = async (query, request) => {
   };
 
   const option = createOption(query, "eapi");
-  option.domain = "https://clientlog.music.163.com";
+  option.domain = CLIENT_LOG_DOMAIN;
 
   const startplay = await request("/api/feedback/weblog", startplayData, option);
   const play = await request("/api/feedback/weblog", playData, option);

--- a/electron/main/apis/netease/modules/scrobble.ts
+++ b/electron/main/apis/netease/modules/scrobble.ts
@@ -8,15 +8,15 @@ import { createOption } from "../core/option";
 import type { NeteaseModule } from "../core/types";
 
 const scrobble: NeteaseModule = async (query, request) => {
-  if (typeof query.cookie === "object" && query.cookie) {
-    query.cookie = { os: "osx", ...query.cookie };
-  } else if (typeof query.cookie === "string") {
-    query.cookie = query.cookie.includes("os=")
-      ? query.cookie.replace(/os=[^;]+/g, "os=osx")
-      : `${query.cookie}; os=osx`;
+  let cookie: string | Record<string, string> = query.cookie || "";
+  if (typeof cookie === "object") {
+    cookie = Object.assign({ os: "osx" }, cookie);
+  } else if (typeof cookie === "string") {
+    cookie = cookie.includes("os=") ? cookie.replace(/os=[^;]+/g, "os=osx") : `${cookie}; os=osx`;
   } else {
-    query.cookie = "os=osx";
+    cookie = "os=osx";
   }
+  query.cookie = cookie;
 
   const startplayData = {
     logs: JSON.stringify([

--- a/electron/main/apis/netease/modules/scrobble_v1.ts
+++ b/electron/main/apis/netease/modules/scrobble_v1.ts
@@ -1,0 +1,119 @@
+/**
+ * 听歌打卡 - NCBL 加密版
+ *
+ * 仿桌面客户端 PLV/PLD 上报。
+ */
+
+import type { NeteaseModule } from "../core/types";
+import {
+  buildCookieStr,
+  buildMetaJson,
+  buildPld,
+  buildPlv,
+  buildRecords,
+  doUpload,
+  extractContext,
+  parseCookie,
+} from "../core/ncbl";
+
+const scrobbleV1: NeteaseModule = async (query) => {
+  const songId = Number(query.id);
+  if (!songId || Number.isNaN(songId)) {
+    return { status: 400, body: { code: 400, msg: "缺少有效的 id (歌曲ID)" }, cookie: [] };
+  }
+  const playTime = Number(query.time);
+  if (Number.isNaN(playTime) || playTime <= 0) {
+    return { status: 400, body: { code: 400, msg: "缺少有效的 time (播放时长)" }, cookie: [] };
+  }
+
+  const totalTime = Number(query.total) || playTime;
+  const sourceId = String(query.sourceid || query.sourceId || "");
+  const sourceName = typeof query.source === "string" ? query.source : "list";
+  const rawCookie = query.cookie || "";
+  const cookieObj = parseCookie(rawCookie);
+  cookieObj.os = "pc";
+  const ctx = extractContext(cookieObj);
+  if (!ctx.auth.token && rawCookie) {
+    const parsed =
+      typeof rawCookie === "string"
+        ? parseCookie(rawCookie)
+        : (rawCookie as Record<string, string>);
+    ctx.auth.token = parsed.MUSIC_U || "";
+  }
+  if (!ctx.auth.token) {
+    return { status: 401, body: { code: 401, msg: "缺少 MUSIC_U 鉴权令牌" }, cookie: [] };
+  }
+
+  const song = {
+    id: songId,
+    name: typeof query.name === "string" ? query.name : "",
+    artist: typeof query.artist === "string" ? query.artist : "",
+    bitrate: Number(query.bitrate) || 320,
+    level: typeof query.level === "string" ? query.level : "exhigh",
+    vip: query.vip === "true" || query.vip === true,
+    time: totalTime,
+  };
+  const source = {
+    id: sourceId || String(songId),
+    type: "track",
+    name: sourceName,
+  };
+  const metaJson = buildMetaJson(ctx);
+  const cookieStr = buildCookieStr(ctx);
+  const ts = Math.floor(Date.now() / 1000);
+  const played = Math.min(playTime, totalTime);
+  const plvBody = buildRecords([{ time: ts, action: "_plv", data: buildPlv(ctx, song, source) }]);
+  const pldBody = buildRecords([
+    { time: ts, action: "_pld", data: buildPld(ctx, song, source, played) },
+  ]);
+
+  try {
+    const plv = await doUpload(ctx, metaJson, plvBody, cookieStr, "PLV");
+    if (!plv.success) {
+      const rate = plv.respBody?.data?.rate;
+      return {
+        status: 200,
+        body: {
+          code: plv.respBody?.code || -1,
+          msg: `PLV 上报失败${rate != null ? ` (rate=${rate})` : ""}`,
+          details: plv.respBody,
+        },
+        cookie: [],
+      };
+    }
+
+    const pld = await doUpload(ctx, metaJson, pldBody, cookieStr, "PLD");
+    if (!pld.success) {
+      return {
+        status: 200,
+        body: {
+          code: pld.respBody?.code || -1,
+          msg: "PLV 成功但 PLD 失败",
+          details: { plv: plv.respBody, pld: pld.respBody },
+        },
+        cookie: [],
+      };
+    }
+
+    return {
+      status: 200,
+      body: {
+        code: 200,
+        data: "scrobble_v1 上报成功",
+        details: {
+          plv: { fileName: plv.fileName, payloadSize: plv.payload.length },
+          pld: { fileName: pld.fileName, payloadSize: pld.payload.length },
+        },
+      },
+      cookie: [],
+    };
+  } catch (err) {
+    return {
+      status: 502,
+      body: { code: 502, msg: `请求异常: ${err instanceof Error ? err.message : String(err)}` },
+      cookie: [],
+    };
+  }
+};
+
+export default scrobbleV1;

--- a/electron/main/apis/netease/modules/scrobble_v1.ts
+++ b/electron/main/apis/netease/modules/scrobble_v1.ts
@@ -33,13 +33,6 @@ const scrobbleV1: NeteaseModule = async (query) => {
   const cookieObj = parseCookie(rawCookie);
   cookieObj.os = "pc";
   const ctx = extractContext(cookieObj);
-  if (!ctx.auth.token && rawCookie) {
-    const parsed =
-      typeof rawCookie === "string"
-        ? parseCookie(rawCookie)
-        : (rawCookie as Record<string, string>);
-    ctx.auth.token = parsed.MUSIC_U || "";
-  }
   if (!ctx.auth.token) {
     return { status: 401, body: { code: 401, msg: "缺少 MUSIC_U 鉴权令牌" }, cookie: [] };
   }
@@ -68,13 +61,13 @@ const scrobbleV1: NeteaseModule = async (query) => {
   ]);
 
   try {
-    const plv = await doUpload(ctx, metaJson, plvBody, cookieStr, "PLV");
+    const plv = await doUpload(ctx, metaJson, plvBody, cookieStr);
     if (!plv.success) {
       const rate = plv.respBody?.data?.rate;
       return {
-        status: 200,
+        status: 502,
         body: {
-          code: plv.respBody?.code || -1,
+          code: 502,
           msg: `PLV 上报失败${rate != null ? ` (rate=${rate})` : ""}`,
           details: plv.respBody,
         },
@@ -82,12 +75,12 @@ const scrobbleV1: NeteaseModule = async (query) => {
       };
     }
 
-    const pld = await doUpload(ctx, metaJson, pldBody, cookieStr, "PLD");
+    const pld = await doUpload(ctx, metaJson, pldBody, cookieStr);
     if (!pld.success) {
       return {
-        status: 200,
+        status: 502,
         body: {
-          code: pld.respBody?.code || -1,
+          code: 502,
           msg: "PLV 成功但 PLD 失败",
           details: { plv: plv.respBody, pld: pld.respBody },
         },

--- a/electron/main/ipc/player.ts
+++ b/electron/main/ipc/player.ts
@@ -8,6 +8,7 @@ import { toMs } from "@main/utils/time";
 import * as mediaService from "@main/services/media";
 import * as nowPlaying from "@main/services/nowPlaying";
 import * as lastfm from "@main/services/lastfm";
+import * as neteaseScrobble from "@main/services/neteaseScrobble";
 import { fetchBytes } from "@main/utils/fetchBytes";
 import { getPlayer, resetPlayer, onPlayerCreated } from "@main/services/engine";
 import { startDevicePolling, stopDevicePolling } from "@main/services/device";
@@ -61,6 +62,7 @@ const registerNativeEvents = (inst: InstanceType<AudioEngineModule["AudioPlayer"
         }
         nowPlaying.onPlayStateChange(state === "playing");
         lastfm.onState(state === "playing");
+        neteaseScrobble.onState(state === "playing");
         const statusEvent = {
           type: "status",
           data: {
@@ -80,6 +82,7 @@ const registerNativeEvents = (inst: InstanceType<AudioEngineModule["AudioPlayer"
         wsBroadcast({ type: "ended" });
         mediaService.setPlayState({ status: "Paused" });
         lastfm.onEnded();
+        neteaseScrobble.onEnded();
         setTaskbarProgress(-1);
         break;
       }
@@ -103,6 +106,7 @@ const registerNativeEvents = (inst: InstanceType<AudioEngineModule["AudioPlayer"
         mediaService.setTimeline({ currentMs: posMs, totalMs: durMs });
         nowPlaying.onPosition(posMs, true);
         lastfm.onPosition();
+        neteaseScrobble.onPosition();
         if (store.get("system.taskbarProgress") && durMs > 0) setTaskbarProgress(posMs / durMs);
         break;
       }
@@ -211,6 +215,7 @@ export const registerPlayerIpc = (): void => {
         durationMs,
         autoPlay,
       });
+      neteaseScrobble.onTrackLoaded(authoritative, durationMs, autoPlay);
       // 远端高清封面
       if (coverUrl) {
         void fetchBytes(coverUrl).then((buf) => {

--- a/electron/main/ipc/player.ts
+++ b/electron/main/ipc/player.ts
@@ -90,6 +90,7 @@ const registerNativeEvents = (inst: InstanceType<AudioEngineModule["AudioPlayer"
         // 音源失效（网络中断 / URL 过期）
         sendToMain("player:event", { type: "sourceError" });
         mediaService.setPlayState({ status: "Paused" });
+        neteaseScrobble.onState(false);
         setTaskbarProgress(-1);
         break;
       }
@@ -106,7 +107,7 @@ const registerNativeEvents = (inst: InstanceType<AudioEngineModule["AudioPlayer"
         mediaService.setTimeline({ currentMs: posMs, totalMs: durMs });
         nowPlaying.onPosition(posMs, true);
         lastfm.onPosition();
-        neteaseScrobble.onPosition();
+        neteaseScrobble.onPosition(posMs);
         if (store.get("system.taskbarProgress") && durMs > 0) setTaskbarProgress(posMs / durMs);
         break;
       }

--- a/electron/main/services/lastfm/scrobbler.ts
+++ b/electron/main/services/lastfm/scrobbler.ts
@@ -1,3 +1,5 @@
+import { createPlayProgress } from "@main/services/playProgress";
+
 /** scrobbler 对外通知的曲目数据 */
 export interface ScrobbleTrack {
   /** 歌曲名 */
@@ -20,39 +22,18 @@ export interface ScrobblerHandlers {
   onScrobble: (track: ScrobbleTrack) => void;
 }
 
-/** 时长低于该值（秒）不 scrobble */
-const SCROBBLE_MIN_DURATION_SEC = 30;
-/** scrobble 最长等待（秒）：min(时长/2, 240) */
-const SCROBBLE_MAX_WAIT_SEC = 240;
-
 let handlers: ScrobblerHandlers | null = null;
 let current: ScrobbleTrack | null = null;
-/** 暂停前已累计的播放毫秒 */
-let playedMs = 0;
-/** 本段播放开始的墙钟时间戳（ms）；未在播放时为 null */
-let playSince: number | null = null;
-/** 当前曲目是否已 scrobble */
-let scrobbled = false;
 /** 当前曲目是否已发过 now playing */
 let nowPlayingSent = false;
+
+const progress = createPlayProgress<ScrobbleTrack>({
+  onThreshold: (track) => handlers?.onScrobble(track),
+});
 
 /** 注入回调 */
 export const setHandlers = (next: ScrobblerHandlers): void => {
   handlers = next;
-};
-
-/** 当前累计实际播放毫秒 */
-const elapsedMs = (): number => playedMs + (playSince != null ? Date.now() - playSince : 0);
-
-/** 达标则 scrobble 一次 */
-const maybeScrobble = (): void => {
-  if (!current || scrobbled) return;
-  if (current.durationSec <= SCROBBLE_MIN_DURATION_SEC) return;
-  const thresholdMs = Math.min(current.durationSec / 2, SCROBBLE_MAX_WAIT_SEC) * 1000;
-  if (elapsedMs() >= thresholdMs) {
-    scrobbled = true;
-    handlers?.onScrobble(current);
-  }
 };
 
 /** 首次实际播放时上报 now playing */
@@ -60,19 +41,6 @@ const sendNowPlaying = (): void => {
   if (!current || nowPlayingSent) return;
   nowPlayingSent = true;
   handlers?.onNowPlaying(current);
-};
-
-/** 结算当前曲目（切歌/结束前调用），达标则补 scrobble，并清空状态 */
-const flush = (): void => {
-  if (playSince != null) {
-    playedMs += Date.now() - playSince;
-    playSince = null;
-  }
-  maybeScrobble();
-  current = null;
-  playedMs = 0;
-  scrobbled = false;
-  nowPlayingSent = false;
 };
 
 /**
@@ -86,27 +54,19 @@ export const onTrackLoaded = (meta: {
   durationMs: number;
   autoPlay: boolean;
 }): void => {
-  flush();
-  if (meta.durationMs <= 0 || !meta.title) {
-    current = null;
-    return;
-  }
-  current = {
-    title: meta.title,
-    artist: meta.artist,
-    album: meta.album,
-    durationSec: Math.round(meta.durationMs / 1000),
-    timestamp: Math.floor(Date.now() / 1000),
-  };
-  playedMs = 0;
-  scrobbled = false;
+  current =
+    meta.durationMs <= 0 || !meta.title
+      ? null
+      : {
+          title: meta.title,
+          artist: meta.artist,
+          album: meta.album,
+          durationSec: Math.round(meta.durationMs / 1000),
+          timestamp: Math.floor(Date.now() / 1000),
+        };
   nowPlayingSent = false;
-  if (meta.autoPlay) {
-    playSince = Date.now();
-    sendNowPlaying();
-  } else {
-    playSince = null;
-  }
+  progress.load(current?.durationSec ?? 0, current, meta.autoPlay);
+  if (current && meta.autoPlay) sendNowPlaying();
 };
 
 /**
@@ -114,31 +74,25 @@ export const onTrackLoaded = (meta: {
  * @param playing - 是否正在播放
  */
 export const onState = (playing: boolean): void => {
-  if (!current) return;
-  if (playing) {
-    if (playSince == null) playSince = Date.now();
-    sendNowPlaying();
-  } else if (playSince != null) {
-    playedMs += Date.now() - playSince;
-    playSince = null;
-  }
+  if (playing) sendNowPlaying();
+  progress.setPlaying(playing);
 };
 
 /** 播放进度推进（驱动阈值检查） */
 export const onPosition = (): void => {
-  maybeScrobble();
+  progress.tick();
 };
 
 /** 自然播放结束 */
 export const onEnded = (): void => {
-  flush();
+  progress.end();
+  current = null;
+  nowPlayingSent = false;
 };
 
 /** 复位（断开连接 / 关闭总开关时） */
 export const reset = (): void => {
+  progress.reset();
   current = null;
-  playedMs = 0;
-  playSince = null;
-  scrobbled = false;
   nowPlayingSent = false;
 };

--- a/electron/main/services/neteaseScrobble.ts
+++ b/electron/main/services/neteaseScrobble.ts
@@ -1,4 +1,6 @@
 import type { Track } from "@shared/types/player";
+import type { NeteaseScrobbleMode } from "@shared/types/settings";
+import { store } from "@main/store";
 import { callNetease, getNeteaseCookies } from "@main/apis/netease";
 import { neteaseLog } from "@main/utils/logger";
 
@@ -6,6 +8,9 @@ interface NeteaseScrobbleTrack {
   id: string;
   sourceId: string;
   title: string;
+  artist: string;
+  bitrate: number;
+  level: string;
   durationSec: number;
 }
 
@@ -42,6 +47,32 @@ const isLoggedIn = (): boolean => Boolean(getNeteaseCookies().MUSIC_U);
 const asNumericId = (value: string | undefined): string | null =>
   value && /^\d+$/.test(value) ? value : null;
 
+/** NCBL 日志使用桌面客户端的音质字段 */
+const toNcblBitrate = (track: Track): number => {
+  const bitRate = track.quality?.bitRate ?? 320;
+  return bitRate > 10000 ? Math.round(bitRate / 1000) : Math.round(bitRate);
+};
+
+/** NCBL 日志使用网易云音质等级 */
+const toNcblLevel = (track: Track): string => {
+  if (track.quality?.codec?.toLowerCase() === "flac") return "lossless";
+  if ((track.quality?.bitRate ?? 0) >= 320000) return "exhigh";
+  return "higher";
+};
+
+/** 当前配置启用的上报接口 */
+const scrobbleApi = (): string => {
+  const mode = (store.get("system.neteaseScrobbleMode") || "ncbl") as NeteaseScrobbleMode;
+  return mode === "ncbl" ? "scrobble_v1" : "scrobble";
+};
+
+/** 检查接口业务码 */
+const ensureScrobbleOk = (api: string, res: { body: any }): void => {
+  if (res.body?.code === 200 || res.body?.data === "success") return;
+  const msg = res.body?.msg || res.body?.message || JSON.stringify(res.body);
+  throw new Error(`${api}: ${msg}`);
+};
+
 /** 从 Track 生成打卡元数据 */
 const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobbleTrack | null => {
   if (!track || track.source !== "netease") return null;
@@ -54,6 +85,9 @@ const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobb
     id,
     sourceId,
     title: track.title,
+    artist: track.artists.map((artist) => artist.name).join(" / "),
+    bitrate: toNcblBitrate(track),
+    level: toNcblLevel(track),
     durationSec,
   };
 };
@@ -68,16 +102,23 @@ const maybeSubmit = (): void => {
   const track = current;
   const requestCycleId = cycleId;
   const playedSec = Math.max(1, Math.min(track.durationSec, Math.round(playedMsNow / 1000)));
-  callNetease("scrobble", {
+  const api = scrobbleApi();
+  callNetease(api, {
     id: track.id,
     sourceid: track.sourceId,
     time: playedSec,
+    total: track.durationSec,
+    name: track.title,
+    artist: track.artist,
+    bitrate: track.bitrate,
+    level: track.level,
   })
-    .then(() => {
-      if (requestCycleId === cycleId) neteaseLog.debug(`听歌打卡: ${track.title}`);
+    .then((res) => {
+      ensureScrobbleOk(api, res);
+      if (requestCycleId === cycleId) neteaseLog.debug(`听歌打卡(${api}): ${track.title}`);
     })
     .catch((err) => {
-      if (requestCycleId === cycleId) neteaseLog.warn("听歌打卡失败:", err);
+      if (requestCycleId === cycleId) neteaseLog.warn(`听歌打卡失败(${api}):`, err);
     });
 };
 

--- a/electron/main/services/neteaseScrobble.ts
+++ b/electron/main/services/neteaseScrobble.ts
@@ -19,8 +19,8 @@ let current: NeteaseScrobbleTrack | null = null;
 let playedMs = 0;
 /** 本段播放开始的墙钟时间戳；未在播放时为 null */
 let playSince: number | null = null;
-/** 当前曲目是否已打卡 */
-let submitted = false;
+/** 当前曲目是否已尝试打卡 */
+let attempted = false;
 
 /** 当前累计实际播放毫秒 */
 const elapsedMs = (): number => playedMs + (playSince != null ? Date.now() - playSince : 0);
@@ -50,16 +50,18 @@ const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobb
 
 /** 达标则提交一次听歌打卡 */
 const maybeSubmit = (): void => {
-  if (!current || submitted) return;
+  if (!current || attempted) return;
   const thresholdMs = Math.min(current.durationSec / 2, SCROBBLE_MAX_WAIT_SEC) * 1000;
-  if (elapsedMs() < thresholdMs) return;
-  submitted = true;
+  const playedMsNow = elapsedMs();
+  if (playedMsNow < thresholdMs) return;
+  attempted = true;
   if (!isLoggedIn()) return;
   const track = current;
+  const playedSec = Math.max(1, Math.min(track.durationSec, Math.round(playedMsNow / 1000)));
   callNetease("scrobble", {
     id: track.id,
     sourceid: track.sourceId,
-    time: track.durationSec,
+    time: playedSec,
   })
     .then(() => neteaseLog.debug(`听歌打卡: ${track.title}`))
     .catch((err) => neteaseLog.warn("听歌打卡失败:", err));
@@ -74,7 +76,7 @@ const flush = (): void => {
   maybeSubmit();
   current = null;
   playedMs = 0;
-  submitted = false;
+  attempted = false;
 };
 
 /**
@@ -87,7 +89,7 @@ export const onTrackLoaded = (track: Track | null, durationMs: number, autoPlay:
   flush();
   current = toScrobbleTrack(track, durationMs);
   playedMs = 0;
-  submitted = false;
+  attempted = false;
   playSince = current && autoPlay ? Date.now() : null;
 };
 

--- a/electron/main/services/neteaseScrobble.ts
+++ b/electron/main/services/neteaseScrobble.ts
@@ -15,15 +15,25 @@ const SCROBBLE_MIN_DURATION_SEC = 30;
 const SCROBBLE_MAX_WAIT_SEC = 240;
 
 let current: NeteaseScrobbleTrack | null = null;
+/** 最近一次加载的可打卡曲目 */
+let loaded: NeteaseScrobbleTrack | null = null;
 /** 暂停前已累计的播放毫秒 */
 let playedMs = 0;
 /** 本段播放开始的墙钟时间戳；未在播放时为 null */
 let playSince: number | null = null;
 /** 当前曲目是否已尝试打卡 */
 let attempted = false;
+/** 上一次收到的源时间位置 */
+let lastPositionMs = 0;
+/** 当前播放轮次，用于丢弃旧请求回包 */
+let cycleId = 0;
 
 /** 当前累计实际播放毫秒 */
 const elapsedMs = (): number => playedMs + (playSince != null ? Date.now() - playSince : 0);
+
+/** 当前曲目的打卡阈值 */
+const thresholdMs = (track: NeteaseScrobbleTrack): number =>
+  Math.min(track.durationSec / 2, SCROBBLE_MAX_WAIT_SEC) * 1000;
 
 /** 是否看起来是网易云登录态 */
 const isLoggedIn = (): boolean => Boolean(getNeteaseCookies().MUSIC_U);
@@ -51,32 +61,54 @@ const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobb
 /** 达标则提交一次听歌打卡 */
 const maybeSubmit = (): void => {
   if (!current || attempted) return;
-  const thresholdMs = Math.min(current.durationSec / 2, SCROBBLE_MAX_WAIT_SEC) * 1000;
   const playedMsNow = elapsedMs();
-  if (playedMsNow < thresholdMs) return;
+  if (playedMsNow < thresholdMs(current)) return;
   attempted = true;
   if (!isLoggedIn()) return;
   const track = current;
+  const requestCycleId = cycleId;
   const playedSec = Math.max(1, Math.min(track.durationSec, Math.round(playedMsNow / 1000)));
   callNetease("scrobble", {
     id: track.id,
     sourceid: track.sourceId,
     time: playedSec,
   })
-    .then(() => neteaseLog.debug(`听歌打卡: ${track.title}`))
-    .catch((err) => neteaseLog.warn("听歌打卡失败:", err));
+    .then(() => {
+      if (requestCycleId === cycleId) neteaseLog.debug(`听歌打卡: ${track.title}`);
+    })
+    .catch((err) => {
+      if (requestCycleId === cycleId) neteaseLog.warn("听歌打卡失败:", err);
+    });
 };
 
-/** 结算当前曲目，切歌/结束前补一次达标检查 */
+/** 重置本轮播放状态 */
+const resetCycle = (): void => {
+  cycleId++;
+  current = null;
+  playedMs = 0;
+  playSince = null;
+  attempted = false;
+  lastPositionMs = 0;
+};
+
+/** 开启一轮播放 */
+const beginCycle = (autoPlay: boolean): void => {
+  cycleId++;
+  current = loaded;
+  playedMs = 0;
+  attempted = false;
+  lastPositionMs = 0;
+  playSince = current && autoPlay ? Date.now() : null;
+};
+
+/** 结算当前播放轮次，切歌/结束前补一次达标检查 */
 const flush = (): void => {
   if (playSince != null) {
     playedMs += Date.now() - playSince;
     playSince = null;
   }
   maybeSubmit();
-  current = null;
-  playedMs = 0;
-  attempted = false;
+  resetCycle();
 };
 
 /**
@@ -87,10 +119,8 @@ const flush = (): void => {
  */
 export const onTrackLoaded = (track: Track | null, durationMs: number, autoPlay: boolean): void => {
   flush();
-  current = toScrobbleTrack(track, durationMs);
-  playedMs = 0;
-  attempted = false;
-  playSince = current && autoPlay ? Date.now() : null;
+  loaded = toScrobbleTrack(track, durationMs);
+  beginCycle(autoPlay);
 };
 
 /**
@@ -101,18 +131,34 @@ export const onState = (playing: boolean): void => {
   if (!current) return;
   if (playing) {
     if (playSince == null) playSince = Date.now();
-  } else if (playSince != null) {
-    playedMs += Date.now() - playSince;
-    playSince = null;
+  } else {
+    if (playSince != null) {
+      playedMs += Date.now() - playSince;
+      playSince = null;
+    }
+    maybeSubmit();
   }
 };
 
-/** 播放进度推进 */
-export const onPosition = (): void => {
+/**
+ * 播放进度推进
+ * @param positionMs - 当前源时间位置
+ */
+export const onPosition = (positionMs: number): void => {
+  if (current && attempted) {
+    const limit = thresholdMs(current);
+    const returnedBeforeThreshold = lastPositionMs >= limit && positionMs < limit;
+    const jumpedBack = positionMs + 1000 < lastPositionMs;
+    if (positionMs < limit && (returnedBeforeThreshold || jumpedBack)) {
+      beginCycle(playSince != null);
+    }
+  }
+  lastPositionMs = positionMs;
   maybeSubmit();
 };
 
 /** 自然播放结束 */
 export const onEnded = (): void => {
   flush();
+  beginCycle(false);
 };

--- a/electron/main/services/neteaseScrobble.ts
+++ b/electron/main/services/neteaseScrobble.ts
@@ -3,6 +3,7 @@ import type { NeteaseScrobbleMode } from "@shared/types/settings";
 import { store } from "@main/store";
 import { callNetease, getNeteaseCookies } from "@main/apis/netease";
 import { neteaseLog } from "@main/utils/logger";
+import { createPlayProgress } from "@main/services/playProgress";
 
 interface NeteaseScrobbleTrack {
   id: string;
@@ -14,34 +15,17 @@ interface NeteaseScrobbleTrack {
   durationSec: number;
 }
 
-/** 时长低于该值不打卡 */
-const SCROBBLE_MIN_DURATION_SEC = 30;
-/** 打卡最长等待：min(时长一半, 240s) */
-const SCROBBLE_MAX_WAIT_SEC = 240;
-
 let current: NeteaseScrobbleTrack | null = null;
-/** 最近一次加载的可打卡曲目 */
-let loaded: NeteaseScrobbleTrack | null = null;
-/** 暂停前已累计的播放毫秒 */
-let playedMs = 0;
-/** 本段播放开始的墙钟时间戳；未在播放时为 null */
-let playSince: number | null = null;
-/** 当前曲目是否已尝试打卡 */
-let attempted = false;
 /** 上一次收到的源时间位置 */
 let lastPositionMs = 0;
 /** 当前播放轮次，用于丢弃旧请求回包 */
 let cycleId = 0;
 
-/** 当前累计实际播放毫秒 */
-const elapsedMs = (): number => playedMs + (playSince != null ? Date.now() - playSince : 0);
-
-/** 当前曲目的打卡阈值 */
-const thresholdMs = (track: NeteaseScrobbleTrack): number =>
-  Math.min(track.durationSec / 2, SCROBBLE_MAX_WAIT_SEC) * 1000;
-
 /** 是否看起来是网易云登录态 */
 const isLoggedIn = (): boolean => Boolean(getNeteaseCookies().MUSIC_U);
+
+/** 听歌打卡是否启用 */
+const isScrobbleEnabled = (): boolean => Boolean(store.get("system.neteaseScrobbleEnabled"));
 
 /** 提取接口可接受的数字 id */
 const asNumericId = (value: string | undefined): string | null =>
@@ -79,8 +63,6 @@ const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobb
   const id = asNumericId(track.id);
   const sourceId = asNumericId(track.album?.id);
   if (!id || !sourceId) return null;
-  const durationSec = Math.round(durationMs / 1000);
-  if (durationSec <= SCROBBLE_MIN_DURATION_SEC) return null;
   return {
     id,
     sourceId,
@@ -88,20 +70,15 @@ const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobb
     artist: track.artists.map((artist) => artist.name).join(" / "),
     bitrate: toNcblBitrate(track),
     level: toNcblLevel(track),
-    durationSec,
+    durationSec: Math.round(durationMs / 1000),
   };
 };
 
-/** 达标则提交一次听歌打卡 */
-const maybeSubmit = (): void => {
-  if (!current || attempted) return;
-  const playedMsNow = elapsedMs();
-  if (playedMsNow < thresholdMs(current)) return;
-  attempted = true;
+/** 达标提交一次打卡（登录态判定在此，关着开关由 shouldFire 拦截） */
+const submit = (track: NeteaseScrobbleTrack, playedMs: number): void => {
   if (!isLoggedIn()) return;
-  const track = current;
   const requestCycleId = cycleId;
-  const playedSec = Math.max(1, Math.min(track.durationSec, Math.round(playedMsNow / 1000)));
+  const playedSec = Math.max(1, Math.min(track.durationSec, Math.round(playedMs / 1000)));
   const api = scrobbleApi();
   callNetease(api, {
     id: track.id,
@@ -122,35 +99,10 @@ const maybeSubmit = (): void => {
     });
 };
 
-/** 重置本轮播放状态 */
-const resetCycle = (): void => {
-  cycleId++;
-  current = null;
-  playedMs = 0;
-  playSince = null;
-  attempted = false;
-  lastPositionMs = 0;
-};
-
-/** 开启一轮播放 */
-const beginCycle = (autoPlay: boolean): void => {
-  cycleId++;
-  current = loaded;
-  playedMs = 0;
-  attempted = false;
-  lastPositionMs = 0;
-  playSince = current && autoPlay ? Date.now() : null;
-};
-
-/** 结算当前播放轮次，切歌/结束前补一次达标检查 */
-const flush = (): void => {
-  if (playSince != null) {
-    playedMs += Date.now() - playSince;
-    playSince = null;
-  }
-  maybeSubmit();
-  resetCycle();
-};
+const progress = createPlayProgress<NeteaseScrobbleTrack>({
+  onThreshold: submit,
+  shouldFire: isScrobbleEnabled,
+});
 
 /**
  * 新曲目加载
@@ -159,9 +111,10 @@ const flush = (): void => {
  * @param autoPlay - 是否自动播放
  */
 export const onTrackLoaded = (track: Track | null, durationMs: number, autoPlay: boolean): void => {
-  flush();
-  loaded = toScrobbleTrack(track, durationMs);
-  beginCycle(autoPlay);
+  cycleId++;
+  current = toScrobbleTrack(track, durationMs);
+  progress.load(current?.durationSec ?? 0, current, autoPlay);
+  lastPositionMs = 0;
 };
 
 /**
@@ -169,16 +122,7 @@ export const onTrackLoaded = (track: Track | null, durationMs: number, autoPlay:
  * @param playing - 是否正在播放
  */
 export const onState = (playing: boolean): void => {
-  if (!current) return;
-  if (playing) {
-    if (playSince == null) playSince = Date.now();
-  } else {
-    if (playSince != null) {
-      playedMs += Date.now() - playSince;
-      playSince = null;
-    }
-    maybeSubmit();
-  }
+  progress.setPlaying(playing);
 };
 
 /**
@@ -186,20 +130,24 @@ export const onState = (playing: boolean): void => {
  * @param positionMs - 当前源时间位置
  */
 export const onPosition = (positionMs: number): void => {
-  if (current && attempted) {
-    const limit = thresholdMs(current);
+  // 已打卡后若用户跳回阈值之前，视为重新收听，重置本轮计时以便再次打卡
+  if (current && progress.hasFired()) {
+    const limit = progress.thresholdMs();
     const returnedBeforeThreshold = lastPositionMs >= limit && positionMs < limit;
     const jumpedBack = positionMs + 1000 < lastPositionMs;
     if (positionMs < limit && (returnedBeforeThreshold || jumpedBack)) {
-      beginCycle(playSince != null);
+      cycleId++;
+      progress.rearm();
     }
   }
   lastPositionMs = positionMs;
-  maybeSubmit();
+  progress.tick();
 };
 
 /** 自然播放结束 */
 export const onEnded = (): void => {
-  flush();
-  beginCycle(false);
+  cycleId++;
+  progress.end();
+  current = null;
+  lastPositionMs = 0;
 };

--- a/electron/main/services/neteaseScrobble.ts
+++ b/electron/main/services/neteaseScrobble.ts
@@ -1,0 +1,116 @@
+import type { Track } from "@shared/types/player";
+import { callNetease, getNeteaseCookies } from "@main/apis/netease";
+import { neteaseLog } from "@main/utils/logger";
+
+interface NeteaseScrobbleTrack {
+  id: string;
+  sourceId: string;
+  title: string;
+  durationSec: number;
+}
+
+/** 时长低于该值不打卡 */
+const SCROBBLE_MIN_DURATION_SEC = 30;
+/** 打卡最长等待：min(时长一半, 240s) */
+const SCROBBLE_MAX_WAIT_SEC = 240;
+
+let current: NeteaseScrobbleTrack | null = null;
+/** 暂停前已累计的播放毫秒 */
+let playedMs = 0;
+/** 本段播放开始的墙钟时间戳；未在播放时为 null */
+let playSince: number | null = null;
+/** 当前曲目是否已打卡 */
+let submitted = false;
+
+/** 当前累计实际播放毫秒 */
+const elapsedMs = (): number => playedMs + (playSince != null ? Date.now() - playSince : 0);
+
+/** 是否看起来是网易云登录态 */
+const isLoggedIn = (): boolean => Boolean(getNeteaseCookies().MUSIC_U);
+
+/** 提取接口可接受的数字 id */
+const asNumericId = (value: string | undefined): string | null =>
+  value && /^\d+$/.test(value) ? value : null;
+
+/** 从 Track 生成打卡元数据 */
+const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobbleTrack | null => {
+  if (!track || track.source !== "netease") return null;
+  const id = asNumericId(track.id);
+  const sourceId = asNumericId(track.album?.id);
+  if (!id || !sourceId) return null;
+  const durationSec = Math.round(durationMs / 1000);
+  if (durationSec <= SCROBBLE_MIN_DURATION_SEC) return null;
+  return {
+    id,
+    sourceId,
+    title: track.title,
+    durationSec,
+  };
+};
+
+/** 达标则提交一次听歌打卡 */
+const maybeSubmit = (): void => {
+  if (!current || submitted) return;
+  const thresholdMs = Math.min(current.durationSec / 2, SCROBBLE_MAX_WAIT_SEC) * 1000;
+  if (elapsedMs() < thresholdMs) return;
+  submitted = true;
+  if (!isLoggedIn()) return;
+  const track = current;
+  callNetease("scrobble", {
+    id: track.id,
+    sourceid: track.sourceId,
+    time: track.durationSec,
+  })
+    .then(() => neteaseLog.debug(`听歌打卡: ${track.title}`))
+    .catch((err) => neteaseLog.warn("听歌打卡失败:", err));
+};
+
+/** 结算当前曲目，切歌/结束前补一次达标检查 */
+const flush = (): void => {
+  if (playSince != null) {
+    playedMs += Date.now() - playSince;
+    playSince = null;
+  }
+  maybeSubmit();
+  current = null;
+  playedMs = 0;
+  submitted = false;
+};
+
+/**
+ * 新曲目加载
+ * @param track - 渲染层下发的权威 Track
+ * @param durationMs - 引擎确认后的时长
+ * @param autoPlay - 是否自动播放
+ */
+export const onTrackLoaded = (track: Track | null, durationMs: number, autoPlay: boolean): void => {
+  flush();
+  current = toScrobbleTrack(track, durationMs);
+  playedMs = 0;
+  submitted = false;
+  playSince = current && autoPlay ? Date.now() : null;
+};
+
+/**
+ * 播放/暂停状态变化
+ * @param playing - 是否正在播放
+ */
+export const onState = (playing: boolean): void => {
+  if (!current) return;
+  if (playing) {
+    if (playSince == null) playSince = Date.now();
+  } else if (playSince != null) {
+    playedMs += Date.now() - playSince;
+    playSince = null;
+  }
+};
+
+/** 播放进度推进 */
+export const onPosition = (): void => {
+  maybeSubmit();
+};
+
+/** 自然播放结束 */
+export const onEnded = (): void => {
+  flush();
+};

--- a/electron/main/services/playProgress.ts
+++ b/electron/main/services/playProgress.ts
@@ -1,0 +1,106 @@
+/** 默认 scrobble 阈值：时长 ≤30s 不触发，否则 min(时长/2, 240s) */
+export const defaultScrobbleThresholdMs = (durationSec: number): number =>
+  durationSec <= 30 ? Infinity : Math.min(durationSec / 2, 240) * 1000;
+
+export interface PlayProgressOptions<T> {
+  /** 累计播放达阈值时触发一次 */
+  onThreshold: (payload: T, playedMs: number) => void;
+  /** 由时长(秒)算出应累计的毫秒阈值；默认 defaultScrobbleThresholdMs */
+  thresholdMs?: (durationSec: number) => number;
+  /** 达阈值时的放行判定；返回 false 则不触发也不置已触发标志，下次推进再判（用于"开关关着时不占用本轮"） */
+  shouldFire?: () => boolean;
+}
+
+export interface PlayProgress<T> {
+  /** 加载新曲目（先结算上一首）；payload 为 null 表示当前不可计时 */
+  load: (durationSec: number, payload: T | null, playing: boolean) => void;
+  /** 播放/暂停状态变化 */
+  setPlaying: (playing: boolean) => void;
+  /** 进度推进时驱动一次达阈值检查 */
+  tick: () => void;
+  /** 同曲重复播放 */
+  rearm: () => void;
+  /** 自然结束：结算并清空 */
+  end: () => void;
+  /** 复位（断开 / 关闭总开关） */
+  reset: () => void;
+  /** 当前累计实际播放毫秒 */
+  elapsedMs: () => number;
+  /** 当前曲目阈值（ms），无曲目返回 Infinity */
+  thresholdMs: () => number;
+  /** 本轮是否已触发 */
+  hasFired: () => boolean;
+}
+
+export const createPlayProgress = <T>(options: PlayProgressOptions<T>): PlayProgress<T> => {
+  const computeThreshold = options.thresholdMs ?? defaultScrobbleThresholdMs;
+  let payload: T | null = null;
+  let durationSec = 0;
+  let playedMs = 0;
+  let playSince: number | null = null;
+  let fired = false;
+
+  const elapsedMs = (): number => playedMs + (playSince != null ? Date.now() - playSince : 0);
+  const thresholdMs = (): number => (payload != null ? computeThreshold(durationSec) : Infinity);
+
+  const maybeFire = (): void => {
+    if (payload == null || fired) return;
+    const played = elapsedMs();
+    if (played < thresholdMs()) return;
+    if (options.shouldFire && !options.shouldFire()) return;
+    fired = true;
+    options.onThreshold(payload, played);
+  };
+
+  const settle = (): void => {
+    if (playSince != null) {
+      playedMs += Date.now() - playSince;
+      playSince = null;
+    }
+    maybeFire();
+  };
+
+  const clear = (): void => {
+    payload = null;
+    durationSec = 0;
+    playedMs = 0;
+    playSince = null;
+    fired = false;
+  };
+
+  return {
+    load: (nextDurationSec, nextPayload, playing) => {
+      settle();
+      clear();
+      payload = nextPayload;
+      durationSec = nextDurationSec;
+      playSince = nextPayload != null && playing ? Date.now() : null;
+    },
+    setPlaying: (playing) => {
+      if (payload == null) return;
+      if (playing) {
+        if (playSince == null) playSince = Date.now();
+      } else if (playSince != null) {
+        playedMs += Date.now() - playSince;
+        playSince = null;
+      }
+      maybeFire();
+    },
+    tick: maybeFire,
+    rearm: () => {
+      if (payload == null) return;
+      const wasPlaying = playSince != null;
+      playedMs = 0;
+      fired = false;
+      playSince = wasPlaying ? Date.now() : null;
+    },
+    end: () => {
+      settle();
+      clear();
+    },
+    reset: clear,
+    elapsedMs,
+    thresholdMs,
+    hasFired: () => fired,
+  };
+};

--- a/electron/main/utils/logger.ts
+++ b/electron/main/utils/logger.ts
@@ -89,4 +89,5 @@ export const downloadLog = log.scope("download");
 export const serverLog = log.scope("server");
 export const pluginLog = log.scope("plugin");
 export const lastfmLog = log.scope("lastfm");
+export const neteaseLog = log.scope("netease");
 export const updaterLog = log.scope("updater");

--- a/shared/defaults/settings.ts
+++ b/shared/defaults/settings.ts
@@ -141,6 +141,7 @@ export const defaultSystemConfig: SystemConfig = {
     uiZoom: 100,
     onboardingCompleted: false,
     neteaseRealIp: false,
+    neteaseScrobbleMode: "ncbl",
     registerOrpheusProtocol: false,
   },
   windowStates: {

--- a/shared/defaults/settings.ts
+++ b/shared/defaults/settings.ts
@@ -141,6 +141,7 @@ export const defaultSystemConfig: SystemConfig = {
     uiZoom: 100,
     onboardingCompleted: false,
     neteaseRealIp: false,
+    neteaseScrobbleEnabled: false,
     neteaseScrobbleMode: "ncbl",
     registerOrpheusProtocol: false,
   },

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -389,7 +389,9 @@ export interface SystemConfig {
     onboardingCompleted: boolean;
     /** NCM请求注入国内 IP（X-Real-IP/X-Forwarded-For） */
     neteaseRealIp: boolean;
-    /** 网易云听歌打卡上报方式 */
+    /** 听歌打卡开关 */
+    neteaseScrobbleEnabled: boolean;
+    /** 听歌打卡上报方式 */
     neteaseScrobbleMode: NeteaseScrobbleMode;
     /** 注册为 Orpheus 协议处理程序，抢占网页端「用客户端打开」 */
     registerOrpheusProtocol: boolean;

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -344,6 +344,9 @@ export interface AppUpdateSettings {
   autoCheck: boolean;
 }
 
+/** 网易云听歌打卡上报方式 */
+export type NeteaseScrobbleMode = "legacy" | "ncbl";
+
 /** 后端配置汇总 */
 export interface SystemConfig {
   /** 播放器配置 */
@@ -386,6 +389,8 @@ export interface SystemConfig {
     onboardingCompleted: boolean;
     /** NCM请求注入国内 IP（X-Real-IP/X-Forwarded-For） */
     neteaseRealIp: boolean;
+    /** 网易云听歌打卡上报方式 */
+    neteaseScrobbleMode: NeteaseScrobbleMode;
     /** 注册为 Orpheus 协议处理程序，抢占网页端「用客户端打开」 */
     registerOrpheusProtocol: boolean;
   };

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1294,6 +1294,12 @@
       "label": "Use Real IP",
       "description": "May be restricted overseas or in some regions; enable this to try to resolve it"
     },
+    "neteaseScrobbleMode": {
+      "label": "NetEase scrobble method",
+      "description": "Choose which reporting interface is used for automatic NetEase listening records",
+      "legacy": "Legacy log API",
+      "ncbl": "NCBL encrypted API"
+    },
     "orpheusProtocol": {
       "label": "Wake this app via the Orpheus protocol",
       "description": "This protocol is normally used by the web player to launch the official client; enabling it may prevent the official client from being launched"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -641,6 +641,7 @@
       "language": "Language",
       "playback": "Player",
       "playControl": "Playback Control",
+      "scrobble": "Scrobble",
       "lyricContent": "Lyric Content",
       "lyricTTML": "TTML Lyrics",
       "lyricExclude": "Metadata Stripping",
@@ -1294,9 +1295,13 @@
       "label": "Use Real IP",
       "description": "May be restricted overseas or in some regions; enable this to try to resolve it"
     },
+    "neteaseScrobbleEnabled": {
+      "label": "Enable scrobble",
+      "description": "Automatically report listening records to NCM after a track has played long enough"
+    },
     "neteaseScrobbleMode": {
-      "label": "NetEase scrobble method",
-      "description": "Choose which reporting interface is used for automatic NetEase listening records",
+      "label": "NCM scrobble method",
+      "description": "Choose which reporting interface is used for automatic NCM listening records",
       "legacy": "Legacy log API",
       "ncbl": "NCBL encrypted API"
     },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1282,6 +1282,12 @@
       "label": "使用真实IP地址",
       "description": "在海外或部分地区可能会受到限制，可开启此处尝试解决"
     },
+    "neteaseScrobbleMode": {
+      "label": "网易云听歌打卡方式",
+      "description": "选择自动同步网易云听歌记录时使用的上报接口",
+      "legacy": "原版日志接口",
+      "ncbl": "NCBL 加密接口"
+    },
     "orpheusProtocol": {
       "label": "通过 Orpheus 协议唤起本应用",
       "description": "该协议通常用于官方网页端唤起官方客户端，启用后可能导致官方客户端无法被唤起"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -629,6 +629,7 @@
       "language": "语言",
       "playback": "播放器",
       "playControl": "播放控制",
+      "scrobble": "听歌打卡",
       "lyricContent": "歌词内容",
       "lyricTTML": "TTML 歌词",
       "lyricExclude": "歌词排除",
@@ -1282,9 +1283,13 @@
       "label": "使用真实IP地址",
       "description": "在海外或部分地区可能会受到限制，可开启此处尝试解决"
     },
+    "neteaseScrobbleEnabled": {
+      "label": "启用听歌打卡",
+      "description": "播放达到一定时长后，自动向 NCM 上报听歌记录"
+    },
     "neteaseScrobbleMode": {
-      "label": "网易云听歌打卡方式",
-      "description": "选择自动同步网易云听歌记录时使用的上报接口",
+      "label": "NCM 听歌打卡方式",
+      "description": "选择自动同步 NCM 听歌记录时使用的上报接口",
       "legacy": "原版日志接口",
       "ncbl": "NCBL 加密接口"
     },

--- a/src/settings/categories/player.ts
+++ b/src/settings/categories/player.ts
@@ -62,6 +62,30 @@ const playerCategory: SettingCategory = {
       ],
     },
     {
+      id: "scrobble",
+      tag: { text: "Beta" },
+      items: [
+        {
+          key: "neteaseScrobbleEnabled",
+          type: "switch",
+          binding: { store: "settings", path: "system.system.neteaseScrobbleEnabled" },
+          defaultValue: false,
+          children: [
+            {
+              key: "neteaseScrobbleMode",
+              type: "select",
+              binding: { store: "settings", path: "system.system.neteaseScrobbleMode" },
+              options: [
+                { value: "legacy", labelKey: "settings.neteaseScrobbleMode.legacy" },
+                { value: "ncbl", labelKey: "settings.neteaseScrobbleMode.ncbl" },
+              ],
+              defaultValue: "ncbl",
+            },
+          ],
+        },
+      ],
+    },
+    {
       id: "playback",
       items: [
         {

--- a/src/settings/categories/services.ts
+++ b/src/settings/categories/services.ts
@@ -16,6 +16,16 @@ const servicesCategory: SettingCategory = {
           binding: { store: "settings", path: "system.system.neteaseRealIp" },
           defaultValue: false,
         },
+        {
+          key: "neteaseScrobbleMode",
+          type: "select",
+          binding: { store: "settings", path: "system.system.neteaseScrobbleMode" },
+          options: [
+            { value: "legacy", labelKey: "settings.neteaseScrobbleMode.legacy" },
+            { value: "ncbl", labelKey: "settings.neteaseScrobbleMode.ncbl" },
+          ],
+          defaultValue: "ncbl",
+        },
       ],
     },
     {

--- a/src/settings/categories/services.ts
+++ b/src/settings/categories/services.ts
@@ -16,16 +16,6 @@ const servicesCategory: SettingCategory = {
           binding: { store: "settings", path: "system.system.neteaseRealIp" },
           defaultValue: false,
         },
-        {
-          key: "neteaseScrobbleMode",
-          type: "select",
-          binding: { store: "settings", path: "system.system.neteaseScrobbleMode" },
-          options: [
-            { value: "legacy", labelKey: "settings.neteaseScrobbleMode.legacy" },
-            { value: "ncbl", labelKey: "settings.neteaseScrobbleMode.ncbl" },
-          ],
-          defaultValue: "ncbl",
-        },
       ],
     },
     {


### PR DESCRIPTION
- 集成 scrobble 模块实现听歌记录上报
- 添加网易云打卡服务处理播放状态和进度跟踪
- 实现播放时长计算和自动打卡逻辑
- 添加最低播放时长限制和最大等待时间控制
- 在播放状态变化、切歌、结束时触发相应打卡操作
- 添加专门的日志记录和错误处理机制
- 将 scrobble 接口加入非缓存列表确保实时性
- 扩展 .gitignore 忽略 IDE 配置文件