### PR TITLE
fix: 全局修正命令

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,25 +35,25 @@ jobs:
             arch: x64
             artifact_name_suffix: windows-x64
             package_extension: zip
-            build_cmd: pnpm build:win -- --x64
+            build_cmd: pnpm build:win --x64
           - os: macos-latest
             name: macOS
             arch: arm64
             artifact_name_suffix: macos-arm64
             package_extension: tar.gz
-            build_cmd: pnpm build:mac -- --arm64
+            build_cmd: pnpm build:mac --arm64
           - os: macos-latest
             name: macOS
             arch: x64
             artifact_name_suffix: macos-x64
             package_extension: tar.gz
-            build_cmd: pnpm build:mac -- --x64
+            build_cmd: pnpm build:mac --x64
           - os: ubuntu-latest
             name: linux
             arch: x64
             artifact_name_suffix: linux-x64
             package_extension: tar.gz
-            build_cmd: pnpm build:linux -- --x64
+            build_cmd: pnpm build:linux --x64
     steps:
       - name: Check out git repository
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,22 +115,22 @@ jobs:
         run: |
           case "${{ matrix.target }}" in
             windows-x64)
-              pnpm build:win -- --x64 --publish never
+              pnpm build:win --x64 --publish never
               ;;
             windows-arm64)
-              pnpm build:win -- --arm64 --publish never
+              pnpm build:win --arm64 --publish never
               ;;
             macos-x64)
-              pnpm build:mac -- --x64 --publish never
+              pnpm build:mac --x64 --publish never
               ;;
             macos-arm64)
-              pnpm build:mac -- --arm64 --publish never
+              pnpm build:mac --arm64 --publish never
               ;;
             linux-x64)
-              pnpm build:linux -- --x64 --publish never
+              pnpm build:linux --x64 --publish never
               ;;
             linux-arm64)
-              pnpm build:linux -- --arm64 --publish never
+              pnpm build:linux --arm64 --publish never
               ;;
             *)
               echo "Unsupported target: ${{ matrix.target }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ pnpm build                # Full build (rimraf → native → typecheck → elec
 pnpm build:{win,mac,linux}# Platform packages
 pnpm typecheck            # tsc + vue-tsc (node + web targets)
 pnpm lint / format        # ESLint / Prettier
-pnpm build:native         # Rust only; add `-- --dev` for debug
+pnpm build:native         # Rust only; add `--dev` for debug
 ```
 
 `SKIP_NATIVE_BUILD=true` skips Rust during dev.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ pnpm build                # Full build (rimraf → native → typecheck → elec
 pnpm build:{win,mac,linux}# Platform packages
 pnpm typecheck            # tsc + vue-tsc (node + web targets)
 pnpm lint / format        # ESLint / Prettier
-pnpm build:native         # Rust only; add `-- --dev` for debug
+pnpm build:native         # Rust only; add `--dev` for debug
 ```
 
 `SKIP_NATIVE_BUILD=true` skips Rust during dev.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pnpm build:linux   # Package for Linux
 ```
 
 > By default a build targets the current architecture only. To target specific
-> architectures, append them, e.g. `pnpm build:win -- --x64 --arm64`.
+> architectures, append them, e.g. `pnpm build:win --x64 --arm64`.
 
 ### Other Scripts
 
@@ -82,7 +82,7 @@ pnpm build:linux   # Package for Linux
 pnpm typecheck        # tsc + vue-tsc (node + web targets)
 pnpm lint             # ESLint
 pnpm format           # Prettier
-pnpm build:native     # Build the Rust native modules only (add `-- --dev` for debug)
+pnpm build:native     # Build the Rust native modules only (add `--dev` for debug)
 ```
 
 ## Acknowledgements

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ pnpm build:mac     # 打包 macOS
 pnpm build:linux   # 打包 Linux
 ```
 
-> 默认仅构建当前架构。如需指定架构，可追加参数，例如 `pnpm build:win -- --x64 --arm64`。
+> 默认仅构建当前架构。如需指定架构，可追加参数，例如 `pnpm build:win --x64 --arm64`。
 
 ### 其他脚本
 
@@ -81,7 +81,7 @@ pnpm build:linux   # 打包 Linux
 pnpm typecheck        # tsc + vue-tsc（node + web 双目标）
 pnpm lint             # ESLint
 pnpm format           # Prettier
-pnpm build:native     # 仅构建 Rust 原生模块（加 `-- --dev` 为 debug 构建）
+pnpm build:native     # 仅构建 Rust 原生模块（加 `--dev` 为 debug 构建）
 ```
 
 ## 致谢

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,7 +57,7 @@ pnpm build:unpack
 pnpm typecheck        # tsc + vue-tsc（node + web 双目标）
 pnpm lint             # ESLint
 pnpm format           # Prettier
-pnpm build:native     # 仅构建 Rust 原生模块（加 `-- --dev` 为 debug 构建）
+pnpm build:native     # 仅构建 Rust 原生模块（加 `--dev` 为 debug 构建）
 ```
 
 ## 项目结构

--- a/docs/native.md
+++ b/docs/native.md
@@ -42,7 +42,7 @@ Windows 任务栏歌词渲染，跟随系统主题与任务栏状态自适应。
 pnpm build:native
 
 # 构建 debug 版本（更快，便于调试）
-pnpm build:native -- --dev
+pnpm build:native --dev
 ```
 
 NAPI-RS 会自动生成各模块的 `index.d.ts` 类型声明，主进程通过路径别名引用：

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typecheck": "pnpm typecheck:node && pnpm typecheck:web",
     "build:native": "tsx scripts/build-native.ts",
     "start": "electron-vite preview",
-    "dev": "pnpm build:native -- --dev && tsx scripts/dev.ts",
+    "dev": "pnpm build:native --dev && tsx scripts/dev.ts",
     "build": "rimraf dist && pnpm build:native && pnpm typecheck && electron-vite build",
     "postinstall": "electron-rebuild -f -w better-sqlite3",
     "build:unpack": "pnpm build && electron-builder --dir --config electron-builder.config.ts",


### PR DESCRIPTION
将 `pnpm build:xxx -- --<arch>` 修正为 `pnpm build:xxx --<arch>`；将 `pnpm build:native -- --dev` 修正为 `pnpm build:native --dev`。前者会直接忽略架构参数，后者因为目前的参数解析逻辑简单所以没有区别

pnpm 自 v7 开始，将 `pnpm run <script>` 后的任何参数都添加到执行的脚本中而不需要 `--` ([文档](https://pnpm.io/zh/next/cli/run)) ([更新说明](https://github.com/pnpm/pnpm/releases/tag/v7.0.0))

我执行了以下操作来筛选出所有使用了这一特性的命令，并修正

```console
$ git grep -- "-- --"
docs/troubleshooting/wayland.md:pnpm dev -- --ozone-platform=x11
```

> `pnpm dev -- --ozone-platform=x11` 是预期的，因为这里的 `--` 传递给了 electron-vite，用于将后面的参数传递给 electron