### PR TITLE
feat: ClassIsland 支持

### DIFF
--- a/electron/main/core/index.ts
+++ b/electron/main/core/index.ts
@@ -20,7 +20,10 @@ import { init as initDownload } from "@main/services/downloadManager";
 import { pluginRegistry } from "@main/plugins/registry";
 import { registerCacheScheme, handleCacheProtocol } from "@main/utils/protocol";
 import { startServer, stopServer } from "@main/server";
-import { init as initLyricsIsland, dispose as disposeLyricsIsland } from "@main/services/lyricsIsland";
+import {
+  init as initLyricsIsland,
+  dispose as disposeLyricsIsland,
+} from "@main/services/lyricsIsland";
 import { initUpdater, disposeUpdater } from "@main/services/updater";
 import { coreLog, initLogger } from "@main/utils/logger";
 import {

--- a/electron/main/core/index.ts
+++ b/electron/main/core/index.ts
@@ -20,6 +20,7 @@ import { init as initDownload } from "@main/services/downloadManager";
 import { pluginRegistry } from "@main/plugins/registry";
 import { registerCacheScheme, handleCacheProtocol } from "@main/utils/protocol";
 import { startServer, stopServer } from "@main/server";
+import { init as initLyricsIsland, dispose as disposeLyricsIsland } from "@main/services/lyricsIsland";
 import { initUpdater, disposeUpdater } from "@main/services/updater";
 import { coreLog, initLogger } from "@main/utils/logger";
 import {
@@ -125,6 +126,8 @@ export const initApp = (): void => {
     initGlobalHotkey();
     // 启动外部 API 服务
     void startServer();
+    // 启动 ClassIsland 联动服务
+    initLyricsIsland();
     // 初始化自动更新
     initUpdater();
     // 周期记录各进程内存
@@ -152,6 +155,7 @@ export const initApp = (): void => {
     shutdownMedia();
     closeDatabase();
     void stopServer();
+    disposeLyricsIsland();
     void pluginRegistry.shutdown();
     disposeUpdater();
   });

--- a/electron/main/services/lyricsIsland.ts
+++ b/electron/main/services/lyricsIsland.ts
@@ -1,0 +1,158 @@
+/**
+ * ClassIsland 联动服务（LyricsIsland 协议客户端）
+ *
+ * 订阅 nowPlaying 事件，按协议向 ClassIsland（ExtraIsland 插件）推送当前歌词。
+ * 协议：POST http://127.0.0.1:{port}/component/lyrics/lyrics/
+ * 请求体：{ "lyric": "<主歌词>", "extra": "<次级歌词>" }
+ */
+
+import type { Track } from "@shared/types/player";
+import type { LyricLine } from "@shared/types/lyrics";
+import type {
+  NowPlayingSnapshot,
+  NowPlayingPositionSync,
+  NowPlayingLyricOffsetSync,
+} from "@shared/types/nowPlaying";
+import { store } from "@main/store";
+import { lyricsIslandLog } from "@main/utils/logger";
+import * as nowPlaying from "@main/services/nowPlaying";
+
+/** 缓存的当前歌词行数组 */
+let lyricLines: LyricLine[] = [];
+/** 当前行索引，-1 表示未匹配 */
+let currentIndex = -1;
+/** 当前歌词偏移（毫秒，正值为歌词提前） */
+let lyricOffsetMs = 0;
+/** 事件订阅取消函数列表 */
+let unsubscribers: Array<() => void> = [];
+
+/**
+ * 从一行歌词中提取纯文本
+ * @param line - 歌词行
+ * @returns 拼接后的文本
+ */
+const lineToText = (line: LyricLine): string => line.words.map((w) => w.word).join("");
+
+/**
+ * 按时间查找当前歌词行索引
+ * 找到 startTime <= time 的最后一行
+ * @param time - 查找时间（毫秒）
+ * @returns 行索引，-1 表示无匹配
+ */
+const findIndex = (time: number): number => {
+  let result = -1;
+  for (let i = 0; i < lyricLines.length; i++) {
+    if (lyricLines[i].startTime <= time) result = i;
+    else break;
+  }
+  return result;
+};
+
+/**
+ * 发送歌词到 ClassIsland
+ * 请求失败静默吞掉，不打印日志（ClassIsland 可能未运行）
+ * @param lyric - 主歌词
+ * @param extra - 次级歌词
+ */
+const send = async (lyric: string, extra: string): Promise<void> => {
+  const port = store.get("lyricsIsland.port");
+  const url = `http://127.0.0.1:${port}/component/lyrics/lyrics/`;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ lyric, extra }),
+    });
+  } catch {
+    // ClassIsland 未运行或端口被占用，静默忽略
+  }
+};
+
+/**
+ * 处理歌曲切换
+ * @param data - 含新 track，null 表示无曲目
+ */
+const onTrackChange = (data: { track: Track | null }): void => {
+  if (!store.get("lyricsIsland.enabled")) return;
+  lyricLines = [];
+  currentIndex = -1;
+  const track = data.track;
+  if (!track) return;
+  const artist = track.artists.map((a) => a.name).join(", ");
+  void send(track.title, artist);
+};
+
+/**
+ * 处理歌词内容变化
+ * @param snap - 当前播放快照
+ */
+const onLyricChange = (snap: NowPlayingSnapshot): void => {
+  if (!store.get("lyricsIsland.enabled")) return;
+  lyricLines = snap.lyric;
+  currentIndex = -1;
+  lyricOffsetMs = snap.lyricOffsetMs;
+};
+
+/**
+ * 处理歌词偏移变化
+ * @param data - 偏移数据
+ */
+const onLyricOffsetChange = (data: NowPlayingLyricOffsetSync): void => {
+  if (!store.get("lyricsIsland.enabled")) return;
+  lyricOffsetMs = data.offsetMs;
+};
+
+/**
+ * 处理播放位置变化
+ * @param data - 位置同步数据
+ */
+const onPositionSync = (data: NowPlayingPositionSync): void => {
+  if (!store.get("lyricsIsland.enabled")) return;
+  if (lyricLines.length === 0) return;
+  const time = data.position + lyricOffsetMs;
+  const next = findIndex(time);
+  if (next === currentIndex) return;
+  currentIndex = next;
+  const current = next >= 0 ? lyricLines[next] : null;
+  const nextLine = next + 1 < lyricLines.length ? lyricLines[next + 1] : null;
+  const lyric = current ? lineToText(current) : "";
+  let extra = "";
+  if (store.get("lyricsIsland.showTranslation") && current?.translatedLyric) {
+    extra = current.translatedLyric;
+  } else if (store.get("lyricsIsland.showNextLine") && nextLine) {
+    extra = lineToText(nextLine);
+  }
+  void send(lyric, extra);
+};
+
+/**
+ * 初始化服务：订阅 nowPlaying 事件
+ * 无论 enabled 是否开启都订阅，在回调中实时检查 enabled，使配置变更立即生效
+ */
+export const init = (): void => {
+  if (unsubscribers.length > 0) return;
+  lyricsIslandLog.info("初始化 ClassIsland 联动服务");
+  unsubscribers = [
+    nowPlaying.onTrackChange(onTrackChange),
+    nowPlaying.onLyricChange(onLyricChange),
+    nowPlaying.onLyricOffsetChange(onLyricOffsetChange),
+    nowPlaying.onPositionSync(onPositionSync),
+  ];
+};
+
+/** 清理：取消所有事件订阅，重置内部状态 */
+export const dispose = (): void => {
+  if (unsubscribers.length === 0) return;
+  lyricsIslandLog.info("关闭 ClassIsland 联动服务");
+  for (const unsub of unsubscribers) {
+    try {
+      unsub();
+    } catch {
+      // ignored
+    }
+  }
+  unsubscribers = [];
+  lyricLines = [];
+  currentIndex = -1;
+  lyricOffsetMs = 0;
+};

--- a/electron/main/services/nowPlaying.ts
+++ b/electron/main/services/nowPlaying.ts
@@ -196,22 +196,30 @@ export const clear = (): void => {
   emitter.emit("lyric-offset-change", { trackId: null, offsetMs: 0 });
 };
 
-/** 订阅歌曲切换 */
-export const onTrackChange = (listener: (data: { track: Track | null }) => void): void => {
+/** 订阅歌曲切换，返回取消订阅函数 */
+export const onTrackChange = (
+  listener: (data: { track: Track | null }) => void,
+): (() => void) => {
   emitter.on("track-change", listener);
+  return () => emitter.off("track-change", listener);
 };
 
-/** 订阅歌词内容变化 */
-export const onLyricChange = (listener: (snap: NowPlayingSnapshot) => void): void => {
+/** 订阅歌词内容变化，返回取消订阅函数 */
+export const onLyricChange = (listener: (snap: NowPlayingSnapshot) => void): (() => void) => {
   emitter.on("lyric-change", listener);
+  return () => emitter.off("lyric-change", listener);
 };
 
-/** 订阅播放位置锚点 */
-export const onPositionSync = (listener: (data: NowPlayingPositionSync) => void): void => {
+/** 订阅播放位置锚点，返回取消订阅函数 */
+export const onPositionSync = (listener: (data: NowPlayingPositionSync) => void): (() => void) => {
   emitter.on("position-sync", listener);
+  return () => emitter.off("position-sync", listener);
 };
 
-/** 订阅当前曲目歌词偏移变化 */
-export const onLyricOffsetChange = (listener: (data: NowPlayingLyricOffsetSync) => void): void => {
+/** 订阅当前曲目歌词偏移变化，返回取消订阅函数 */
+export const onLyricOffsetChange = (
+  listener: (data: NowPlayingLyricOffsetSync) => void,
+): (() => void) => {
   emitter.on("lyric-offset-change", listener);
+  return () => emitter.off("lyric-offset-change", listener);
 };

--- a/electron/main/services/nowPlaying.ts
+++ b/electron/main/services/nowPlaying.ts
@@ -197,9 +197,7 @@ export const clear = (): void => {
 };
 
 /** 订阅歌曲切换，返回取消订阅函数 */
-export const onTrackChange = (
-  listener: (data: { track: Track | null }) => void,
-): (() => void) => {
+export const onTrackChange = (listener: (data: { track: Track | null }) => void): (() => void) => {
   emitter.on("track-change", listener);
   return () => emitter.off("track-change", listener);
 };

--- a/electron/main/utils/logger.ts
+++ b/electron/main/utils/logger.ts
@@ -92,3 +92,4 @@ export const lastfmLog = log.scope("lastfm");
 export const neteaseLog = log.scope("netease");
 export const updaterLog = log.scope("updater");
 export const cloudLog = log.scope("cloud");
+export const lyricsIslandLog = log.scope("lyricsIsland");

--- a/shared/defaults/settings.ts
+++ b/shared/defaults/settings.ts
@@ -133,6 +133,12 @@ export const defaultSystemConfig: SystemConfig = {
     allowLan: false,
     port: 14558,
   },
+  lyricsIsland: {
+    enabled: false,
+    port: 50063,
+    showTranslation: true,
+    showNextLine: true,
+  },
   update: {
     autoCheck: true,
   },

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -222,6 +222,18 @@ export interface ExternalApiSettings {
   port: number;
 }
 
+/** ClassIsland 联动（LyricsIsland 协议）配置 */
+export interface LyricsIslandSettings {
+  /** 总开关 */
+  enabled: boolean;
+  /** 目标端口（协议固定 50063，提供配置以防特殊场景） */
+  port: number;
+  /** 次级歌词优先显示翻译 */
+  showTranslation: boolean;
+  /** 无翻译时显示下一行原文 */
+  showNextLine: boolean;
+}
+
 /** 外部 API 服务运行时状态 */
 export interface ExternalApiStatus {
   /** 是否正在监听 */
@@ -377,6 +389,8 @@ export interface SystemConfig {
   lastfm: LastfmSettings;
   /** 外部 API 服务（HTTP + WS） */
   externalApi: ExternalApiSettings;
+  /** ClassIsland 联动（LyricsIsland 协议） */
+  lyricsIsland: LyricsIslandSettings;
   /** 应用更新配置 */
   update: AppUpdateSettings;
   /** 系统配置 */

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -679,6 +679,7 @@
       "discord": "Discord RPC",
       "lastfm": "Last.fm",
       "externalApi": "External API",
+      "lyricsIsland": "ClassIsland",
       "systemConfig": "System",
       "pluginsList": "Installed Plugins",
       "streaming": "Streaming",
@@ -1429,6 +1430,22 @@
     "externalApiPanel": {
       "label": "",
       "description": ""
+    },
+    "lyricsIslandEnabled": {
+      "label": "Enable ClassIsland integration",
+      "description": "Push current lyrics to ClassIsland home screen (requires ExtraIsland plugin)"
+    },
+    "lyricsIslandPort": {
+      "label": "Port",
+      "description": "ClassIsland listen port (default 50063, usually no need to change)"
+    },
+    "lyricsIslandShowTranslation": {
+      "label": "Show translation",
+      "description": "Prefer translated lyrics for the secondary line"
+    },
+    "lyricsIslandShowNextLine": {
+      "label": "Show next line",
+      "description": "Show next line original lyrics when no translation available"
     },
     "externalApi": {
       "restart": "Restart server",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -667,6 +667,7 @@
       "discord": "Discord RPC",
       "lastfm": "Last.fm",
       "externalApi": "外部 API",
+      "lyricsIsland": "ClassIsland 联动",
       "systemConfig": "系统配置",
       "pluginsList": "已安装插件",
       "streaming": "流媒体管理",
@@ -1417,6 +1418,22 @@
     "externalApiPanel": {
       "label": "",
       "description": ""
+    },
+    "lyricsIslandEnabled": {
+      "label": "启用 ClassIsland 联动",
+      "description": "将当前歌词推送到 ClassIsland 主界面显示（需安装 ExtraIsland 插件）"
+    },
+    "lyricsIslandPort": {
+      "label": "端口",
+      "description": "ClassIsland 监听端口（默认 50063，一般无需修改）"
+    },
+    "lyricsIslandShowTranslation": {
+      "label": "显示翻译",
+      "description": "次级歌词优先显示翻译歌词"
+    },
+    "lyricsIslandShowNextLine": {
+      "label": "显示下一行",
+      "description": "无翻译时显示下一行原文"
     },
     "externalApi": {
       "restart": "重启服务",

--- a/src/settings/categories/externalLyric.ts
+++ b/src/settings/categories/externalLyric.ts
@@ -341,6 +341,41 @@ const taskbarLyricSection: SettingSection = {
   ],
 };
 
+const lyricsIslandSection: SettingSection = {
+  id: "lyricsIsland",
+  tag: { text: "Beta" },
+  items: [
+    {
+      key: "lyricsIslandEnabled",
+      type: "switch",
+      binding: { store: "settings", path: "system.lyricsIsland.enabled" },
+      defaultValue: false,
+      children: [
+        {
+          key: "lyricsIslandPort",
+          type: "number",
+          binding: { store: "settings", path: "system.lyricsIsland.port" },
+          min: 1024,
+          max: 65535,
+          defaultValue: 50063,
+        },
+        {
+          key: "lyricsIslandShowTranslation",
+          type: "switch",
+          binding: { store: "settings", path: "system.lyricsIsland.showTranslation" },
+          defaultValue: true,
+        },
+        {
+          key: "lyricsIslandShowNextLine",
+          type: "switch",
+          binding: { store: "settings", path: "system.lyricsIsland.showNextLine" },
+          defaultValue: true,
+        },
+      ],
+    },
+  ],
+};
+
 const externalLyricCategory: SettingCategory = {
   id: "externalLyric",
   icon: IconLucideMonitor,
@@ -349,6 +384,7 @@ const externalLyricCategory: SettingCategory = {
     dynamicIslandSection,
     // taskbarLyric 仅 Windows 可用
     ...(navigator.platform.startsWith("Win") ? [taskbarLyricSection] : []),
+    lyricsIslandSection,
   ],
 };
 


### PR DESCRIPTION
# 背景

SPlayer-Next 当前已具备桌面歌词、灵动岛、任务栏歌词等"本应用内"的歌词展示能力，但无法将歌词推送到班级大屏课表软件 ClassIsland 主界面。

ClassIsland 生态已有成熟的 **LyricsIsland 协议**：
- **ExtraIsland 插件**（ClassIsland 插件）作为 HTTP 服务器，监听 `http://127.0.0.1:50063/`
- **LyricsIslandBNCM**（网易云音乐 BetterNCM 插件）作为客户端，向上述地址推送歌词

本 PR 让 SPlayer-Next 作为该协议的客户端，复用 ClassIsland 主界面这一展示位，扩大应用的使用场景。

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/427616fb-b264-45ec-b63d-5178bada2171" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e62a8759-ccfa-4ded-ac28-0535c9cb86bc" />

# 改动内容

## 新增
- **`electron/main/services/lyricsIsland.ts`**：LyricsIsland 协议客户端核心服务
  - 订阅 `nowPlaying` 的 `track-change` / `lyric-change` / `lyric-offset-change` / `position-sync` 事件
  - 歌曲切换时推送歌名 + 歌手
  - 歌词行变化时推送当前行原文 + 翻译/下一行
  - 请求失败静默处理（ClassIsland 未运行时不影响播放）

## 修改
- **`shared/types/settings.ts`**：新增 `LyricsIslandSettings` 接口，`SystemConfig` 新增 `lyricsIsland` 字段
- **`shared/defaults/settings.ts`**：新增 `lyricsIsland` 默认值（`enabled: false`、`port: 50063`、`showTranslation: true`、`showNextLine: true`）
- **`electron/main/services/nowPlaying.ts`**：`onTrackChange` / `onLyricChange` / `onPositionSync` / `onLyricOffsetChange` 四个订阅方法改为返回取消订阅函数（便于服务清理资源）
- **`electron/main/utils/logger.ts`**：新增 `lyricsIslandLog` scoped logger
- **`electron/main/core/index.ts`**：`app.whenReady` 中调用 `initLyricsIsland()`，`before-quit` 中调用 `disposeLyricsIsland()`
- **`src/settings/categories/externalLyric.ts`**：新增"ClassIsland 联动"section（带 Beta 标签），含总开关与三个子项
- **`src/i18n/locales/zh-CN.json`** / **`en-US.json`**：新增中英文文案

# 实现细节

## 协议一致性
- 请求路径：`POST /component/lyrics/lyrics/`（与 ExtraIsland `LyricsIslandLyricsProvider.cs` 一致）
- 请求体：`{ "lyric": "<主歌词>", "extra": "<次级歌词>" }`
- 默认端口：`50063`（与 ExtraIsland、LyricsIslandBNCM `base.js` 一致）
- 歌曲切换时发送歌名 + 歌手（与 LyricsIslandBNCM `lyric.js` 行为一致）

## 配置变更即时生效
服务在事件回调中实时读取 `store.get("lyricsIsland.enabled")` 等配置，用户在设置页切换开关后无需重启应用即可生效。

## 歌词行定位逻辑
- 用 `position + lyricOffsetMs` 作为查找时间（支持用户调整的歌词偏移）
- 遍历 `LyricLine[]` 找到 `startTime <= time` 的最大索引行
- 仅当行索引变化时发送请求（避免高频 HTTP 请求）
- 次级歌词优先级：翻译 > 下一行原文 > 空字符串

## 节流策略
- `position-sync` 频率约 5Hz，但只在歌词行索引变化时发 HTTP 请求
- HTTP 请求失败静默处理，不重试（避免 ClassIsland 未运行时日志爆炸）

# 使用说明

1. 在 ClassIsland 中安装 **ExtraIsland** 插件（提供 LyricsIsland 协议服务端）
2. 打开 SPlayer-Next → 设置 → 外部歌词 → **ClassIsland 联动**
3. 开启"启用 ClassIsland 联动"开关
4. 播放音乐，歌词将显示在 ClassIsland 主界面

可选配置：
- **端口**：默认 50063，一般无需修改
- **显示翻译**：次级歌词优先显示翻译歌词
- **显示下一行**：无翻译时显示下一行原文

# 测试验证

- [x] `pnpm typecheck:node` 通过
- [x] `pnpm typecheck:web` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm dev` 构建启动成功
- [x] [Windows 构建](https://github.com/WindDrift/SPlayer-Next/actions/runs/28105654710) 测试通过

# 设计决策

## 为什么放在主进程？
1. `nowPlaying` 服务在主进程，可直接订阅其 EventEmitter，无 IPC 开销
2. HTTP 请求在主进程发送，不阻塞渲染层
3. 与现有 `lastfm`、`externalApi` 等主进程服务架构一致
4. 配置通过主进程 `store` 读取，无需额外 IPC

## 为什么不用现有的外部 API（HTTP+WS）服务器？
外部 API 是"被动响应外部请求"，而 LyricsIsland 需要"主动推送"给 ClassIsland。两者方向相反，且外部 API 默认关闭、端口可配，不适合作为 LyricsIsland 的载体。

# Edit
- 换了一张图片以体现翻译行在 ClassIsland 主界面歌词副行的效果。
- 加了一张图片以体现新增的设置项。