### PR TITLE
feat(search): 添加艺术家搜索结果点击导航功能

### DIFF
--- a/src/components/layout/SideBar.vue
+++ b/src/components/layout/SideBar.vue
@@ -58,9 +58,7 @@ const handleCreate = (): void => {
 
 /** 新建成功后跳转到该歌单 */
 const handleCreated = (playlistId: string, scope: ContentScope): void => {
-  router.push(
-    `/collection/${scope === "local" ? "local" : "netease"}/playlist/${playlistId}`,
-  );
+  router.push(`/collection/${scope === "local" ? "local" : "netease"}/playlist/${playlistId}`);
 };
 
 /** 我的歌单分组头部 */

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -6,7 +6,7 @@ import { searchSongs, searchAlbums, searchArtists, searchPlaylists } from "@/api
 import SongList from "@/components/list/SongList.vue";
 import CoverList from "@/components/list/CoverList.vue";
 import { useStatusStore } from "@/stores/status";
-import { navigateToAlbum, navigateToPlaylist } from "@/utils/navigate";
+import { navigateToAlbum, navigateToArtist, navigateToPlaylist } from "@/utils/navigate";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -273,6 +273,10 @@ const isEmptyResult = computed(() => {
         :padding-bottom="20"
         :has-more="states.artists.hasMore"
         :loading-more="states.artists.loadingMore"
+        @click="
+          (item) =>
+            navigateToArtist(item.title, { source: status.searchPlatform, artistId: item.id })
+        "
         @reach-bottom="onReachBottom('artists')"
       />
       <CoverList


### PR DESCRIPTION
- 在 Search.vue 中导入 navigateToArtist 函数
- 为艺术家列表添加点击事件处理器
- 点击艺术家项目时调用 navigateToArtist 进行页面跳转
- 传递艺术家标题、源平台和ID作为参数
- 移除 SideBar.vue 中路由跳转的多余括号以优化代码格式

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/40d7d328-141a-4bed-932d-cd6d9671b731" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/60ba88bc-ea7d-429a-bebc-e683f5f81ca3" />
