### PR TITLE
fix: 修正 VIP 判断逻辑

### DIFF
--- a/src/utils/format/netease.ts
+++ b/src/utils/format/netease.ts
@@ -22,12 +22,12 @@ export const ensureOk = <T>(body: T): T => {
 
 /**
  *  fee → 应用层 TrackFee
- *  fee：0=免费 1=VIP 4=购买专辑 8=会员高音质（视作 VIP）
+ *  fee：0=免费 1=VIP 4=购买专辑 8=会员高音质（视作免费）
  * @param fee - 原始 fee
  */
 const toTrackFee = (fee: number | undefined): TrackFee | undefined => {
-  if (fee === 0) return 0;
-  if (fee === 1 || fee === 8) return 1;
+  if (fee === 0 || fee === 8) return 0;
+  if (fee === 1) return 1;
   if (fee === 4) return 2;
   return undefined;
 };


### PR DESCRIPTION
将「会员高音质」也视作免费。这符合逻辑（可以免费听低音质），也符合官方客户端的显示逻辑

<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

将「会员高音质」也视作免费。这符合逻辑（可以免费听低音质），也符合官方客户端的显示逻辑

## 测试情况

对比了我的歌单中修复后 SPlayer Next 和官方客户端（Android）显示 VIP 徽标的情况，均符合

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
