### PR TITLE
fix(ui): 更换桌面歌词图标避免误解

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -77,6 +77,7 @@ declare module 'vue' {
     IconLucideBookOpen: typeof import('~icons/lucide/book-open')['default']
     IconLucideCalendar: typeof import('~icons/lucide/calendar')['default']
     IconLucideCalendarDays: typeof import('~icons/lucide/calendar-days')['default']
+    IconLucideCaptions: typeof import('~icons/lucide/captions')['default']
     IconLucideCheck: typeof import('~icons/lucide/check')['default']
     IconLucideChevronDown: typeof import('~icons/lucide/chevron-down')['default']
     IconLucideChevronLeft: typeof import('~icons/lucide/chevron-left')['default']

--- a/src/components/player/Toolbar.vue
+++ b/src/components/player/Toolbar.vue
@@ -120,7 +120,7 @@ const onMoreMenuSelect = (key: string): void => {
       :class="isDesktopLyricOpen ? undefined : mutedClass"
       @click="toggleDesktopLyric"
     >
-      <template #icon><IconLucideMicVocal /></template>
+      <template #icon><IconLucideCaptions /></template>
     </SButton>
     <SButton
       v-if="!status.fmMode && cover"


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

主页底栏上桌面歌词的图标不好（`mic-vocal` 人声麦克风），根本想不到是桌面歌词，~~不知道的还以为是 k 歌~~

现在换成了 `captions`（字幕）

## 测试情况

比以前好（

## 截图 / 录屏

<img width="446" height="205" alt="图片" src="https://github.com/user-attachments/assets/147b8aaa-e3e2-4a0d-a619-1bb7404e7e4b" />

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
