### PR TITLE
fix: 在重启前写入设置

### DIFF
--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -13,6 +13,7 @@ import { fetchBytes } from "@main/utils/fetchBytes";
 import { logsDir } from "@main/utils/paths";
 import { consumePendingOrpheusUrl } from "@main/services/orpheus";
 import { testNetworkProxy } from "@main/utils/proxy";
+import { store } from "@main/store";
 
 /**
  * 注册系统相关的 IPC 事件
@@ -72,6 +73,7 @@ export const registerSystemIpc = (): void => {
 
   // 重启应用
   ipcMain.handle("system:relaunch", () => {
+    store.flushImmediate();
     app.relaunch();
     app.exit(0);
   });

--- a/electron/main/store/index.ts
+++ b/electron/main/store/index.ts
@@ -131,4 +131,7 @@ export const store = {
     data = deepMerge(defaultSystemConfig, raw);
     flushImmediate(data);
   },
+
+  /** 立即将设置写入磁盘 */
+  flushImmediate: () => flushImmediate(data),
 };


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

暴露 `flushImmediate` 接口以在需要时主动触发设置项落盘，并在需要重启软件时触发。

## 关联 Issue

Closes #102 

## 测试情况

启动软件，在设置项中关闭或打开“无边框窗口”，按照指示重启软件后设置项被正确保存。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
