### PR TITLE
fix(lyric): 智能选择模式下 TTML 覆盖遵循格式优先级

### DIFF
--- a/src/services/lyricResolve.ts
+++ b/src/services/lyricResolve.ts
@@ -194,16 +194,11 @@ const shouldTryTTMLByFormat = (mainFormat: LyricFormat): boolean => {
   return ttmlIdx < mainIdx;
 };
 
-/** 支持 AMLL TTML DB 的平台列表，按用户格式优先级无关的固定顺序 */
+/** 支持 AMLL TTML DB 的平台列表 */
 const TTML_PLATFORMS: readonly ("netease" | "qqmusic")[] = ["netease", "qqmusic"];
 
 /**
  * 拉取在线歌词对应的 TTML 覆盖版本
- *
- * 遍历所有支持 TTML 的平台（NCM + QM）依次尝试，而非仅尝试 online 结果所在平台。
- * 这样在「智能选择」模式下，即使主歌词来自 QQ 音乐（QRC），
- * 仍能从网易云 AMLL DB 拿到 TTML 覆盖（如果 NCM 有而 QM 没有）。
- *
  * @param track - 歌曲信息
  * @param online - 在线歌词结果
  */
@@ -212,15 +207,21 @@ export const resolveTTMLOverlay = async (
   online: OnlineResult,
 ): Promise<ResolvedLyric | null> => {
   if (!shouldTryTTMLByFormat(online.source.format)) return null;
-  for (const platform of TTML_PLATFORMS) {
-    const resp = await window.api.lyrics.fetchTTMLOverlay(track, platform);
-    if (!resp.ok || !resp.data) continue;
-    return {
-      source: { source: "online", format: "ttml", platform },
-      input: { content: resp.data },
-    };
-  }
-  return null;
+  const candidates = await Promise.all(
+    TTML_PLATFORMS.map(async (platform) => ({
+      platform,
+      response: await window.api.lyrics.fetchTTMLOverlay(track, platform),
+    })),
+  );
+  const match = candidates.find(
+    (candidate): candidate is typeof candidate & { response: { ok: true; data: string } } =>
+      candidate.response.ok && !!candidate.response.data,
+  );
+  if (!match) return null;
+  return {
+    source: { source: "online", format: "ttml", platform: match.platform },
+    input: { content: match.response.data },
+  };
 };
 
 /**

--- a/src/services/lyricResolve.ts
+++ b/src/services/lyricResolve.ts
@@ -179,15 +179,10 @@ export const resolveOnlineByPreference = async (
 };
 
 /**
- * 是否对该平台尝试 TTML 升级
- * @param platform - 平台
- * @param mainFormat - 主格式
+ * 判断是否应该尝试 TTML 升级（与平台无关，仅看格式优先级）
+ * @param mainFormat - 当前主歌词格式
  */
-export const shouldTryTTML = (
-  platform: Platform,
-  mainFormat: LyricFormat,
-): platform is "netease" | "qqmusic" => {
-  if (platform !== "netease" && platform !== "qqmusic") return false;
+const shouldTryTTMLByFormat = (mainFormat: LyricFormat): boolean => {
   const settings = useSettingsStore();
   if (!settings.system.lyric.enableOnlineTTMLLyric) return false;
   if (settings.lyric.lyricSourcePreference === "self") return false;
@@ -199,8 +194,16 @@ export const shouldTryTTML = (
   return ttmlIdx < mainIdx;
 };
 
+/** 支持 AMLL TTML DB 的平台列表，按用户格式优先级无关的固定顺序 */
+const TTML_PLATFORMS: readonly ("netease" | "qqmusic")[] = ["netease", "qqmusic"];
+
 /**
  * 拉取在线歌词对应的 TTML 覆盖版本
+ *
+ * 遍历所有支持 TTML 的平台（NCM + QM）依次尝试，而非仅尝试 online 结果所在平台。
+ * 这样在「智能选择」模式下，即使主歌词来自 QQ 音乐（QRC），
+ * 仍能从网易云 AMLL DB 拿到 TTML 覆盖（如果 NCM 有而 QM 没有）。
+ *
  * @param track - 歌曲信息
  * @param online - 在线歌词结果
  */
@@ -208,13 +211,16 @@ export const resolveTTMLOverlay = async (
   track: Track,
   online: OnlineResult,
 ): Promise<ResolvedLyric | null> => {
-  if (!shouldTryTTML(online.source.platform, online.source.format)) return null;
-  const resp = await window.api.lyrics.fetchTTMLOverlay(track, online.source.platform);
-  if (!resp.ok || !resp.data) return null;
-  return {
-    source: { source: "online", format: "ttml", platform: online.source.platform },
-    input: { content: resp.data },
-  };
+  if (!shouldTryTTMLByFormat(online.source.format)) return null;
+  for (const platform of TTML_PLATFORMS) {
+    const resp = await window.api.lyrics.fetchTTMLOverlay(track, platform);
+    if (!resp.ok || !resp.data) continue;
+    return {
+      source: { source: "online", format: "ttml", platform },
+      input: { content: resp.data },
+    };
+  }
+  return null;
 };
 
 /**


### PR DESCRIPTION
## 问题

当歌词来源偏好为「智能选择」时，用户配置的歌词格式优先级（如 `TTML > LYS > QRC > KRC > YRC > LRC`）失效：

- 「NCM 优先」下可正常获取 TTML 歌词的歌曲（《蝴蝶》《反乌托邦Pt.2》等）
- 切换到「智能选择」后却退而获取低优先级的 QRC 并最终显示

## 根因

`resolveTTMLOverlay` 只尝试「在线主歌词所在平台」的 AMLL TTML DB：

- 智能选择下，主歌词可能从 QQ 音乐拿到 QRC（QRC 排名高于 NCM 的 YRC）
- 若该歌曲在 AMLL DB 仅有网易云版本而无 QQ 版本，单平台尝试失败
- TTML 升级路径被跳过，回退到主歌词 QRC，TTML 优先级失效

## 改动

`src/services/lyricResolve.ts`

1. **`shouldTryTTML` → `shouldTryTTMLByFormat`（私有）**
   - 去除 `platform: Platform` 参数与 `platform is "netease" | "qqmusic"` 类型守卫
   - 平台白名单下沉到 `resolveTTMLOverlay` 的 `TTML_PLATFORMS` 常量
   - 仅按用户配置的格式优先级决定是否尝试 TTML 升级

2. **`resolveTTMLOverlay` 重写**
   - 从「仅尝试 `online.source.platform`」改为遍历 `["netease", "qqmusic"]` 依次尝试
   - 命中即返回；解决主歌词平台 ≠ AMLL DB 命中平台时的回退问题

## 验证

- `pnpm typecheck` 通过（tsc + vue-tsc）
- `shouldTryTTML` 全仓 grep 确认无外部调用方依赖被移除的 export
- 复现场景（智能选择 + AMLL DB 仅 NCM 有匹配）下 TTML 现可正常覆盖