### PR TITLE
fix: AMLL 歌词在最小化恢复后逐词位置同步和渲染卡顿问题

### DIFF
--- a/src/components/player/Lyrics/AMLLLyrics.vue
+++ b/src/components/player/Lyrics/AMLLLyrics.vue
@@ -130,6 +130,8 @@ const handleVisibility = () => {
     } else {
       playerRef.value?.pause();
     }
+    // 恢复后立即 update(0) 校准 Core 内部时钟，避免逐词效果丢失
+    playerRef.value?.update(0);
     resumeRaf();
   }
 };

--- a/src/components/player/Lyrics/AMLLLyrics.vue
+++ b/src/components/player/Lyrics/AMLLLyrics.vue
@@ -2,6 +2,8 @@
 import type { LyricLine } from "@shared/types/lyrics";
 import { LyricPlayer as CoreLyricPlayer } from "@applemusic-like-lyrics/core";
 import { useSettingsStore } from "@/stores/settings";
+import { useStatusStore } from "@/stores/status";
+import { getCurrentTime } from "@/services/playback";
 import "@applemusic-like-lyrics/core/style.css";
 import "./renderer.css";
 
@@ -49,15 +51,19 @@ interface Emits {
 const emit = defineEmits<Emits>();
 
 const settings = useSettingsStore();
+const status = useStatusStore();
 const wrapperRef = ref<HTMLDivElement | null>(null);
 const playerRef = ref<CoreLyricPlayer>();
 const bottomLineEl = ref<HTMLElement>();
 const clockInitialized = ref(false);
-
-// 是否被父组件冻结
+// 父组件的冻结标志（由 FullPlayer 的 freeze/resume 控制）
 const isFrozen = ref(false);
 // 冻结期间缓存的待应用歌词
 let pendingLyrics: LyricLine[] | null = null;
+// 页面隐藏状态的响应式跟踪
+const isPageHidden = ref(false);
+// 之前隐藏的标记，用于检测从隐藏恢复的时刻
+const isPreviousHidden = ref(false);
 
 // 处理多语言显隐及音译偏好的本地高效清洗
 const processedLyrics = computed(() => {
@@ -119,20 +125,20 @@ const { resume: resumeRaf, pause: pauseRaf } = useRafFn(
   { immediate: false },
 );
 
-// 页面隐藏时停止渲染循环
+// 页面隐藏时停止渲染循环，恢复时校准时间线
 const handleVisibility = () => {
-  if (document.hidden) {
+  const hidden = document.hidden;
+  isPageHidden.value = hidden; // 更新响应式隐藏状态
+  if (hidden) {
     pauseRaf();
     playerRef.value?.pause();
-  } else if (!isFrozen.value) {
-    if (props.playing) {
-      playerRef.value?.resume();
-    } else {
-      playerRef.value?.pause();
-    }
-    // 恢复后立即 update(0) 校准 Core 内部时钟，避免逐词效果丢失
-    playerRef.value?.update(0);
-    resumeRaf();
+    isPreviousHidden.value = true;
+  } else if (isPreviousHidden.value && !isFrozen.value && playerRef.value) {
+    // 从隐藏恢复：校准 Core 内部时钟到当前播放位置，避免逐词效果从头开始
+    const currentTime = getCurrentTime() + status.lyricOffsetMs;
+    playerRef.value.setCurrentTime(currentTime, true);
+    isPreviousHidden.value = false;
+    // 恢复后根据当前状态决定 resume/pause（由 watchEffect 处理，这里只需确保 state sync）
   }
 };
 
@@ -178,22 +184,29 @@ onUnmounted(() => {
   }
 });
 
-// 播放/暂停/冻结状态变化时同步渲染循环与 Core 内部时钟
+// 同步播放/冻结状态到 Core 及渲染循环
 watchEffect(() => {
   const player = playerRef.value;
   if (!player) return;
+
+  // 首次运行时校准一次（避免重复）
   if (!clockInitialized.value) {
-    player.resume();
     player.update(0);
     clockInitialized.value = true;
   }
-  if (!isFrozen.value && !document.hidden) {
-    if (props.playing) {
+
+  const playing = props.playing;
+  const frozen = isFrozen.value;
+  const hidden = isPageHidden.value; // 使用响应式隐藏状态
+
+  if (!frozen && !hidden) {
+    // 只要未冻结且可见，就持续运行 RAF 维持渲染（即使暂停也要保持画面）
+    resumeRaf();
+    if (playing) {
       player.resume();
     } else {
       player.pause();
     }
-    resumeRaf();
   } else {
     pauseRaf();
     player.pause();


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

<!-- 这个 PR 做了什么、为什么这么做（动机 + 主要变更），尽量描述清楚 -->

使用 AMLL 歌词引擎时，在全屏播放状态下将窗口最小化（触发 `document.hidden = true`），恢复后会出现以下两个问题：

1. 逐词效果从错误位置开始：歌词的逐字高亮动画从当前时间点的之前位置重新开始，导致文字效果"从头飞起"，与音频进度不同步。
2. 暂停后卡死不动：恢复后歌词完全静止不动，需要再次切换播放/暂停状态才能恢复正常渲染。

本 pr 主要对这两个方面进行修复



TODO：
- [x] 继续后让动画回归当前状态，而不是暂停之前的
- [x] 暂停最小化时再播放修复
- [x] 暂停最小化修复
- [x] 播放最小化修复

## 测试情况

<!-- 如何验证这些改动？手动复现步骤、覆盖到的平台（Windows / macOS / Linux）等 -->

最小化 → 恢复播放：逐词动画从正确位置继续
最小化 → 恢复暂停：歌词静止可见，无卡死
普通播放/暂停：正常渲染
FullPlayer freeze/resume：状态同步正确

测试环境：Windows 25H2 Insider

## 截图 / 录屏

<!-- 涉及 UI 改动请附上；无则可删除本节 -->

https://qfile.qq.com/q/vSNQe2TTag

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
