### PR TITLE
fix: 固定 FFT 采样率以防止频谱在高采样率环境显示异常

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -114,7 +114,6 @@ declare module 'vue' {
     IconLucideMessageCircle: typeof import('~icons/lucide/message-circle')['default']
     IconLucideMessageCircleOff: typeof import('~icons/lucide/message-circle-off')['default']
     IconLucideMic: typeof import('~icons/lucide/mic')['default']
-    IconLucideMicVocal: typeof import('~icons/lucide/mic-vocal')['default']
     IconLucideMinimize: typeof import('~icons/lucide/minimize')['default']
     IconLucideMinus: typeof import('~icons/lucide/minus')['default']
     IconLucideMoreHorizontal: typeof import('~icons/lucide/more-horizontal')['default']

--- a/native/audio-engine/src/decoder.rs
+++ b/native/audio-engine/src/decoder.rs
@@ -14,18 +14,26 @@ use crate::priority;
 use crate::shared::{AudioChunk, AudioMetadata, Shared};
 
 /// 播放输出目标格式（重采样后送入 rodio）
-pub const TARGET_SAMPLE_RATE: u32 = 48000;
 pub const TARGET_CHANNELS: u16 = 2;
+
+/// 播放输出默认采样率
+pub const DEFAULT_TARGET_SAMPLE_RATE: u32 = 48_000;
+
+/// FFT 计算所需的目标采样率
+pub const FFT_TARGET_SAMPLE_RATE: u32 = 48_000;
 
 /// 自定义 File IO 读取失败时，ffmpeg_audio 的 read 回调可能映射为此错误码
 const AVERROR_EIO: i32 = sys::averror(libc::EIO);
 
 /// 解码会话所需的资源（跨 seek 复用，避免重建 ffmpeg_audio 上下文）
 ///
-/// 播放重采样器输出设备采样率的 stereo f32，FFT 按需复用这份 PCM
+/// 此处必须进行 1-to-N 分发，因为需要两个可能存在采样率差异的音源
+///  - 播放重采样器输出设备采样率的 stereo f32
+///  - FFT 重采样器输出 48kHz 的 stereo f32
 pub struct DecoderData {
     reader: AudioReader,
     player_resampler: Resampler,
+    fft_resampler: Resampler,
     /// 网络中断句柄仅由远端源持有，stop() 取消后可在 seek 前重置
     interrupt: Option<HttpInterrupt>,
 }
@@ -33,7 +41,7 @@ pub struct DecoderData {
 impl DecoderData {
     /// 在已有 reader 上 seek，失败时调用方应回退到完整 load
     ///
-    /// seek 后重采样器要 flush 掉残留样本，否则播放会带上上一段尾巴
+    /// seek 后两个重采样器要 flush 掉残留样本，否则播放/FFT会带上上一段尾巴
     pub fn seek(&mut self, position_secs: f64) -> bool {
         if let Some(interrupt) = &self.interrupt {
             interrupt.reset();
@@ -45,6 +53,7 @@ impl DecoderData {
             return false;
         }
         let _ = self.player_resampler.flush();
+        let _ = self.fft_resampler.flush();
         true
     }
 
@@ -65,7 +74,7 @@ pub fn start_decode(
 ) -> Result<(AudioMetadata, JoinHandle<DecoderData>)> {
     // 播放重采样目标 = 输出设备原生采样率
     let target_rate = shared.sample_rate();
-    let (reader, player_resampler, interrupt) = open_source(source, target_rate, Some(&shared))?;
+    let (reader, player_resampler, fft_resampler, interrupt) = open_source(source, target_rate, Some(&shared))?;
 
     let info = reader.source_info();
     let duration_secs = reader.duration().map(|d| d.as_secs_f64()).unwrap_or(0.0);
@@ -107,6 +116,7 @@ pub fn start_decode(
     let data = DecoderData {
         reader,
         player_resampler,
+        fft_resampler,
         interrupt,
     };
 
@@ -153,7 +163,7 @@ fn open_source(
     source: &str,
     target_rate: u32,
     shared: Option<&Shared>,
-) -> Result<(AudioReader, Resampler, Option<HttpInterrupt>)> {
+) -> Result<(AudioReader, Resampler, Resampler, Option<HttpInterrupt>)> {
     let (reader, cancel) = if source.starts_with("http://") || source.starts_with("https://") {
         let http = HttpRangeSource::new(source)?;
         let cancel = http.interrupt_handle();
@@ -178,10 +188,18 @@ fn open_source(
         .build_resampler(player_opts)
         .with_context(|| "构建播放重采样器失败")?;
 
-    Ok((reader, player_resampler, cancel))
+    let fft_opts = ResampleOptions::new()
+        .sample_rate(FFT_TARGET_SAMPLE_RATE as i32)
+        .channels(i32::from(TARGET_CHANNELS))
+        .format::<f32>();
+    let fft_resampler = reader
+        .build_resampler(fft_opts)
+        .with_context(|| "构建 FFT 重采样器失败")?;
+
+    Ok((reader, player_resampler, fft_resampler, cancel))
 }
 
-/// 核心解码循环：每帧解码一次并重采样到输出设备格式
+/// 核心解码循环：每帧解码一次，零拷贝分发到播放 + FFT 两个重采样器
 fn run_decoding_loop(data: &mut DecoderData, shared: &Shared) {
     // 响度归一化：有 ReplayGain 标签时用固定增益，否则用实时分析
     let has_replay_gain = (shared.normalization_gain() - 1.0).abs() > f32::EPSILON;
@@ -199,6 +217,7 @@ fn run_decoding_loop(data: &mut DecoderData, shared: &Shared) {
 
         match data.reader.receive_frame() {
             Ok(Some(frame)) => {
+                // 1-to-N: 同一帧顺序喂两个重采样器
                 if data.player_resampler.process::<f32>(Some(&frame)).is_err() {
                     debug!("player resampler 处理失败，结束解码");
                     shared.mark_decode_failed();
@@ -206,8 +225,15 @@ fn run_decoding_loop(data: &mut DecoderData, shared: &Shared) {
                 }
                 let mut player_samples = data.player_resampler.output_as::<f32>().to_vec();
 
+                if data.fft_resampler.process::<f32>(Some(&frame)).is_err() {
+                    debug!("fft resampler 处理失败，结束解码");
+                    shared.mark_decode_failed();
+                    return;
+                }
+                let fft_samples = data.fft_resampler.output_as::<f32>().to_vec();
+
                 // 重采样可能还在攒样本，本轮没出数据就跳过
-                if player_samples.is_empty() {
+                if player_samples.is_empty() && fft_samples.is_empty() {
                     continue;
                 }
                 had_success = true;
@@ -225,14 +251,22 @@ fn run_decoding_loop(data: &mut DecoderData, shared: &Shared) {
                     }
                 }
 
-                shared.push(AudioChunk { player_samples });
+                shared.push(AudioChunk {
+                    player_samples,
+                    fft_samples,
+                });
             }
             Ok(None) | Err(AudioError::Eof) => {
-                // EOF flush：把重采样器内部残留挤出来，否则最后几十毫秒丢
+                // EOF flush：把两个重采样器内部残留挤出来，否则最后几十毫秒丢
                 let _ = data.player_resampler.process::<f32>(None);
+                let _ = data.fft_resampler.process::<f32>(None);
                 let player_samples = data.player_resampler.output_as::<f32>().to_vec();
-                if !player_samples.is_empty() {
-                    shared.push(AudioChunk { player_samples });
+                let fft_samples = data.fft_resampler.output_as::<f32>().to_vec();
+                if !player_samples.is_empty() || !fft_samples.is_empty() {
+                    shared.push(AudioChunk {
+                        player_samples,
+                        fft_samples,
+                    });
                 }
                 return;
             }

--- a/native/audio-engine/src/fft.rs
+++ b/native/audio-engine/src/fft.rs
@@ -1,10 +1,12 @@
 use parking_lot::Mutex;
 use rustfft::{num_complex::Complex, Fft, FftPlanner};
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 /// 每次 FFT 的样本数
 const FFT_SIZE: usize = 2048;
+/// FFT 输入采样率
+const FFT_SAMPLE_RATE: u32 = 48_000;
 /// 输出频段数
 const OUTPUT_BINS: usize = 128;
 /// 分析频率范围
@@ -17,8 +19,6 @@ const MAX_BUFFER_SIZE: usize = 8192;
 pub struct FftAnalyzer {
     /// 双声道样本环形缓冲区（由播放线程写入）
     sample_buffer: Mutex<StereoSampleBuffer>,
-    /// FFT 输入采样率
-    sample_rate: AtomicU32,
     /// 是否接收样本并执行频谱分析
     enabled: AtomicBool,
     /// 缓存的 FFT 计划（避免每次分析时重建）
@@ -45,7 +45,7 @@ struct FftWorkBuffers {
 }
 
 impl FftAnalyzer {
-    pub fn new(sample_rate: u32) -> Self {
+    pub fn new() -> Self {
         let mut planner = FftPlanner::<f32>::new();
         let fft_plan = planner.plan_fft_forward(FFT_SIZE);
         let window = (0..FFT_SIZE)
@@ -62,7 +62,6 @@ impl FftAnalyzer {
                 write_pos: 0,
                 len: 0,
             }),
-            sample_rate: AtomicU32::new(sample_rate),
             enabled: AtomicBool::new(false),
             fft_plan,
             window,
@@ -98,11 +97,6 @@ impl FftAnalyzer {
     /// 是否启用频谱分析
     pub fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
-    }
-
-    /// 更新输入 PCM 采样率
-    pub fn set_sample_rate(&self, sample_rate: u32) {
-        self.sample_rate.store(sample_rate, Ordering::Relaxed);
     }
 
     /// 应用预计算的 Hamming 窗
@@ -143,7 +137,7 @@ impl FftAnalyzer {
         self.fft_plan.process(&mut work.windowed_r);
 
         // 将频率段映射到输出频段
-        let freq_per_bin = self.sample_rate.load(Ordering::Relaxed) as f32 / FFT_SIZE as f32;
+        let freq_per_bin = FFT_SAMPLE_RATE as f32 / FFT_SIZE as f32;
         let min_bin = (MIN_FREQ / freq_per_bin).floor() as usize;
         let max_bin = ((MAX_FREQ / freq_per_bin).ceil() as usize).min(FFT_SIZE / 2);
 
@@ -204,7 +198,7 @@ mod tests {
 
     #[test]
     fn interleaved_samples_wrap_without_mixing_channels() {
-        let analyzer = FftAnalyzer::new(48_000);
+        let analyzer = FftAnalyzer::new();
         let samples: Vec<f32> = (0..MAX_BUFFER_SIZE + 16)
             .flat_map(|i| [i as f32, -(i as f32)])
             .collect();
@@ -221,7 +215,7 @@ mod tests {
 
     #[test]
     fn reset_discards_buffered_samples() {
-        let analyzer = FftAnalyzer::new(48_000);
+        let analyzer = FftAnalyzer::new();
         analyzer.push_interleaved_samples(&[0.5, -0.5, 0.25, -0.25]);
 
         analyzer.reset();

--- a/native/audio-engine/src/loudness.rs
+++ b/native/audio-engine/src/loudness.rs
@@ -49,7 +49,7 @@ pub struct LoudnessAnalyzer {
 }
 
 impl LoudnessAnalyzer {
-    /// 按目标采样率/声道数推算窗口尺寸，避免硬编码与 TARGET_SAMPLE_RATE 解耦后失配
+    /// 按目标采样率/声道数推算窗口尺寸
     pub fn new(sample_rate: u32, channels: u16) -> Self {
         let samples_per_sec = sample_rate as f32 * channels as f32;
         Self {

--- a/native/audio-engine/src/player.rs
+++ b/native/audio-engine/src/player.rs
@@ -203,7 +203,7 @@ impl InnerPlayer {
         self.output
             .as_ref()
             .map(|out| out.sample_rate())
-            .unwrap_or(decoder::TARGET_SAMPLE_RATE)
+            .unwrap_or(decoder::DEFAULT_TARGET_SAMPLE_RATE)
     }
 
     /// 把 EQ / stretch 的采样率对齐到当前输出设备率
@@ -213,7 +213,6 @@ impl InnerPlayer {
         let rate = self.output_sample_rate();
         self.equalizer.lock().set_sample_rate(rate);
         self.tempo.lock().set_sample_rate(rate);
-        self.fft.set_sample_rate(rate);
     }
 
     pub fn new() -> Result<Self> {
@@ -224,7 +223,7 @@ impl InnerPlayer {
         let initial_rate = output
             .as_ref()
             .map(|out| out.sample_rate())
-            .unwrap_or(decoder::TARGET_SAMPLE_RATE);
+            .unwrap_or(decoder::DEFAULT_TARGET_SAMPLE_RATE);
         debug!("InnerPlayer 已创建");
 
         Ok(Self {
@@ -232,7 +231,7 @@ impl InnerPlayer {
             sink: None,
             shared: None,
             decoder_thread: None,
-            fft: Arc::new(FftAnalyzer::new(initial_rate)),
+            fft: Arc::new(FftAnalyzer::new()),
             audio_sample_rate: 0,
             audio_channels: 0,
             audio_duration: 0.0,

--- a/native/audio-engine/src/shared.rs
+++ b/native/audio-engine/src/shared.rs
@@ -10,6 +10,8 @@ use parking_lot::{Condvar, Mutex};
 pub struct AudioChunk {
     /// 交错排列的 f32 播放样本（L R L R ...）
     pub player_samples: Vec<f32>,
+    /// 交错排列的 f32 FFT 样本（L R L R ...）
+    pub fft_samples: Vec<f32>,
 }
 
 /// 非阻塞弹出缓冲区的结果

--- a/native/audio-engine/src/source.rs
+++ b/native/audio-engine/src/source.rs
@@ -105,7 +105,7 @@ impl Iterator for DecoderSource {
                 // 将 FFT 样本推送给分析器
                 PopResult::Chunk(chunk) => {
                     if self.fft.is_enabled() {
-                        self.fft.push_interleaved_samples(&chunk.player_samples);
+                        self.fft.push_interleaved_samples(&chunk.fft_samples);
                     }
 
                     // 填充本地缓冲，一次性批量计数（而非逐采样）
@@ -179,6 +179,7 @@ mod tests {
         let shared = Shared::new(48000, 2);
         shared.push(AudioChunk {
             player_samples: vec![0.8, -0.8],
+            fft_samples: vec![],
         });
 
         let equalizer = Arc::new(Mutex::new(Equalizer::new(48000)));
@@ -190,7 +191,7 @@ mod tests {
 
         let mut source = DecoderSource::new(
             shared,
-            Arc::new(FftAnalyzer::new(48000)),
+            Arc::new(FftAnalyzer::new()),
             equalizer,
             Arc::new(Mutex::new(StretchProcessor::new(2, 48000))),
             48000,
@@ -206,11 +207,12 @@ mod tests {
         let shared = Shared::new(48000, 2);
         shared.push(AudioChunk {
             player_samples: vec![0.1, -0.1, 2.0, -2.0],
+            fft_samples: vec![],
         });
 
         let mut source = DecoderSource::new(
             shared,
-            Arc::new(FftAnalyzer::new(48000)),
+            Arc::new(FftAnalyzer::new()),
             Arc::new(Mutex::new(Equalizer::new(48000))),
             Arc::new(Mutex::new(StretchProcessor::new(2, 48000))),
             48000,
@@ -228,7 +230,7 @@ mod tests {
         let shared = Shared::new(1000, 2);
         let mut source = DecoderSource::new(
             Arc::clone(&shared),
-            Arc::new(FftAnalyzer::new(1000)),
+            Arc::new(FftAnalyzer::new()),
             Arc::new(Mutex::new(Equalizer::new(1000))),
             Arc::new(Mutex::new(StretchProcessor::new(2, 1000))),
             1000,
@@ -238,6 +240,7 @@ mod tests {
         assert_eq!(source.next(), Some(0.0));
         shared.push(AudioChunk {
             player_samples: vec![0.25, -0.25],
+            fft_samples: vec![],
         });
         for _ in 0..39 {
             assert_eq!(source.next(), Some(0.0));


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [x] 是（请在「改动说明」中详细描述）
- [ ] 否

## 改动说明

将在 3995aa8c3af3f760514d4e990ee14264c1365527 中合并的两个重采样器重新分离，因为 8b9a91fc73518a0caf25f3265db44d3de1c49770 导致播放器采样率会随设备环境改变，进而使 FFT 的输入采样率改变而导致频谱异常。现在给 FFT 单独提供 48kHz 信号防止频谱随设备采样率改变。

## 关联 Issue

Closes #113 

## 测试情况

如 #113 中那样测试，可见频谱中阶梯消失

## 截图 / 录屏

**前**
<img width="1541" height="891" alt="7011e9835d1f21aeb00e172476fca02a" src="https://github.com/user-attachments/assets/fb02c4c2-0fdb-42bf-b152-eb6e2a754b10" />
<img width="1449" height="135" alt="6836279d4cf6f2b8cfc0ee91ace900d3" src="https://github.com/user-attachments/assets/c4a6050d-3731-4dd7-bc25-a45253ba1c40" />


**后**
<img width="2815" height="1824" alt="7fac795e4699dae9db0949fd287b9689" src="https://github.com/user-attachments/assets/d7b91341-fe4b-42c6-b764-ed09e1616a14" />

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [ ] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过（未修改TypeScript部分）
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
