### PR TITLE
feat: 增强歌词语言识别逻辑以支持中日混合歌词

### DIFF
--- a/src/utils/lyric/language.test.ts
+++ b/src/utils/lyric/language.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import type { LyricLine } from "@shared/types/lyrics";
 import { applyLyricLanguages } from "./language";
 
-const createLine = (content: string): LyricLine => ({
+const createLine = (content: string, options: Partial<LyricLine> = {}): LyricLine => ({
   words: [{ word: content, startTime: 0, endTime: 1000 }],
   translatedLyric: "",
   romanLyric: "",
@@ -11,6 +11,7 @@ const createLine = (content: string): LyricLine => ({
   endTime: 1000,
   isBG: false,
   isDuet: false,
+  ...options,
 });
 
 describe("applyLyricLanguages", () => {
@@ -22,6 +23,17 @@ describe("applyLyricLanguages", () => {
     assert.deepEqual(
       lines.map((line) => line.language),
       ["ja", "ja"],
+    );
+  });
+
+  it("通过翻译推断双语混合歌曲的纯汉字行", () => {
+    const lines = [createLine("爱"), createLine("君が好き", { translatedLyric: "我喜欢你" })];
+
+    applyLyricLanguages(lines);
+
+    assert.deepEqual(
+      lines.map((line) => line.language),
+      ["zh-CN", "ja"],
     );
   });
 

--- a/src/utils/lyric/language.ts
+++ b/src/utils/lyric/language.ts
@@ -1,4 +1,4 @@
-import type { LyricLanguage, LyricLine } from "@shared/types/lyrics";
+import type { LyricLine } from "@shared/types/lyrics";
 
 /** 日语假名：平假名 + 片假名 + 半角假名 + 促音/长音符号 */
 const KANA_RE = /[\p{Script=Hiragana}\p{Script=Katakana}\u30FC\uFF66-\uFF9F]/u;
@@ -12,28 +12,67 @@ const HAN_RE = /\p{Script=Han}/u;
 /** 拉丁字母；数字与标点不能作为英文判断依据 */
 const LATIN_RE = /\p{Script=Latin}/u;
 
+/** 判断是否有实质内容的翻译歌词 */
+const hasTranslation = (line: LyricLine): boolean => line.translatedLyric.trim().length > 0;
+
 /**
  * 为歌词行补充语言信息
  *
- * Han 脚本无法独立区分中日；同一首歌词出现假名时，将纯汉字行视为日语，
- * 否则视为中文。拉丁文字使用 BCP 47 的 und-Latn，避免误标为英语。
+ * Han 脚本无法独立区分中日韩；
+ * - 同一首歌词出现假名时，通常将纯汉字行视为日语；
+ * - 同一首歌词出现谚文时，通常将纯汉字行视为韩语；
+ * - CJK 混合启发式规则：若所有包含假名/谚文的行均有翻译，
+ *   则认定全为汉字且无翻译的行为中文，以此区分双语混合歌词。
+ * - 拉丁文字使用 BCP 47 的 und-Latn，避免误标为英语。
  *
  * @param lines - 已解析的整首歌词
  */
 export const applyLyricLanguages = (lines: LyricLine[]): void => {
-  const contents = lines.map((line) => line.words.map((word) => word.word).join(""));
-  const hanLanguage: LyricLanguage = contents.some((content) => KANA_RE.test(content))
-    ? "ja"
-    : contents.some((content) => HANGUL_RE.test(content))
-      ? "ko"
-      : "zh-CN";
+  const lineContents = lines.map((line) => line.words.map((word) => word.word).join(""));
+
+  let hasKana = false;
+  let hasHangul = false;
+  let kanaUntranslatedCount = 0;
+  let hangulUntranslatedCount = 0;
 
   for (let i = 0; i < lines.length; i++) {
-    const content = contents[i];
-    if (KANA_RE.test(content)) lines[i].language = "ja";
-    else if (HANGUL_RE.test(content)) lines[i].language = "ko";
-    else if (HAN_RE.test(content)) lines[i].language = hanLanguage;
-    else if (LATIN_RE.test(content)) lines[i].language = "und-Latn";
-    else delete lines[i].language;
+    const content = lineContents[i];
+    const isTranslated = hasTranslation(lines[i]);
+
+    if (KANA_RE.test(content)) {
+      hasKana = true;
+      if (!isTranslated) kanaUntranslatedCount++;
+    }
+    if (HANGUL_RE.test(content)) {
+      hasHangul = true;
+      if (!isTranslated) hangulUntranslatedCount++;
+    }
+  }
+
+  const allKanaTranslated = hasKana && kanaUntranslatedCount === 0;
+  const allHangulTranslated = hasHangul && hangulUntranslatedCount === 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const content = lineContents[i];
+    const isTranslated = hasTranslation(line);
+
+    if (KANA_RE.test(content)) {
+      line.language = "ja";
+    } else if (HANGUL_RE.test(content)) {
+      line.language = "ko";
+    } else if (HAN_RE.test(content)) {
+      if (hasKana) {
+        line.language = allKanaTranslated && !isTranslated ? "zh-CN" : "ja";
+      } else if (hasHangul) {
+        line.language = allHangulTranslated && !isTranslated ? "zh-CN" : "ko";
+      } else {
+        line.language = "zh-CN";
+      }
+    } else if (LATIN_RE.test(content)) {
+      line.language = "und-Latn";
+    } else {
+      delete line.language;
+    }
   }
 };


### PR DESCRIPTION
## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

优化 `applyLyricLanguages`，增加判断，若所有有假名的行都有翻译，那么可以认定全为汉字且无翻译的行是中文

代码由 AI 生成，已由人工审核

## 测试情况

已补充测试，测试通过

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
