### PR TITLE
feat: 添加页面内搜索快捷键

### DIFF
--- a/shared/defaults/hotkeys.ts
+++ b/shared/defaults/hotkeys.ts
@@ -133,6 +133,12 @@ export const HOTKEY_ACTIONS: HotkeyActionMeta[] = [
     defaultBinding: { inApp: "CommandOrControl+F", global: null },
     allowGlobal: false,
   },
+  {
+    id: "view.searchInPage",
+    labelKey: "settings.hotkeys.actions.searchInPage",
+    defaultBinding: { inApp: "/", global: null },
+    allowGlobal: false,
+  },
 ];
 
 /** 默认绑定表（HotkeyBindingsMap） */

--- a/shared/types/hotkey.ts
+++ b/shared/types/hotkey.ts
@@ -19,7 +19,8 @@ export type HotkeyActionId =
   | "view.openPlayer"
   | "view.closePlayer"
   | "view.togglePlaylist"
-  | "view.openSearch";
+  | "view.openSearch"
+  | "view.searchInPage";
 
 /** 单个动作的两条作用域绑定 */
 export interface HotkeyBinding {

--- a/src/components/ui/SInput.vue
+++ b/src/components/ui/SInput.vue
@@ -117,8 +117,7 @@ const handleEnter = (event: KeyboardEvent): void => {
 };
 
 const handleEscape = (event: KeyboardEvent): void => {
-  if (props.updateOn !== "blur") return;
-  rollbackValue();
+  if (props.updateOn === "blur") rollbackValue();
   (event.currentTarget as HTMLInputElement).blur();
 };
 </script>

--- a/src/core/hotkey/registry.ts
+++ b/src/core/hotkey/registry.ts
@@ -92,6 +92,16 @@ export const buildRegistry = (): void => {
   handlers.set("view.openSearch", () => {
     useStatusStore().searchOpen = true;
   });
+  // 聚焦页面内搜索框
+  handlers.set("view.searchInPage", (): boolean => {
+    if (useStatusStore().isPlayerExpanded) return false;
+    const el = document.querySelector<HTMLInputElement>("[data-search-input] input");
+    if (!el || el.disabled) return false;
+    el.focus();
+    if (document.activeElement !== el) return false;
+    el.select();
+    return true;
+  });
 };
 
 /**

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -954,7 +954,8 @@
         "openPlayer": "Open player view",
         "closePlayer": "Close player view",
         "togglePlaylist": "Show / hide playlist",
-        "openSearch": "Open search"
+        "openSearch": "Open search",
+        "searchInPage": "Search in page"
       }
     },
     "engine": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -942,7 +942,8 @@
         "openPlayer": "打开播放界面",
         "closePlayer": "关闭播放界面",
         "togglePlaylist": "展开 / 收起播放列表",
-        "openSearch": "打开搜索"
+        "openSearch": "打开搜索",
+        "searchInPage": "页面内搜索"
       }
     },
     "engine": {

--- a/src/pages/Artist.vue
+++ b/src/pages/Artist.vue
@@ -302,6 +302,7 @@ const albumItems = computed<CoverItem[]>(() => {
               clearable
               round
               class="w-40 focus-within:w-56"
+              data-search-input
             >
               <template #prefix>
                 <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />

--- a/src/pages/Cloud.vue
+++ b/src/pages/Cloud.vue
@@ -131,6 +131,7 @@ watch(
           clearable
           round
           class="w-40 focus-within:w-56"
+          data-search-input
         >
           <template #prefix>
             <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />

--- a/src/pages/Collection.vue
+++ b/src/pages/Collection.vue
@@ -299,6 +299,7 @@ onBeforeUnmount(() => {
               clearable
               round
               class="w-40 focus-within:w-56"
+              data-search-input
             >
               <template #prefix>
                 <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />

--- a/src/pages/History.vue
+++ b/src/pages/History.vue
@@ -87,6 +87,7 @@ onMounted(() => {
             clearable
             round
             class="w-40 focus-within:w-56"
+            data-search-input
           >
             <template #prefix>
               <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />

--- a/src/pages/Library.vue
+++ b/src/pages/Library.vue
@@ -177,6 +177,7 @@ onUnmounted(() => {
           clearable
           round
           class="w-40 focus-within:w-56"
+          data-search-input
         >
           <template #prefix>
             <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />

--- a/src/pages/Liked.vue
+++ b/src/pages/Liked.vue
@@ -140,6 +140,7 @@ const handleMoreMenu = (key: string): void => {
             clearable
             round
             class="w-40 focus-within:w-56"
+            data-search-input
           >
             <template #prefix>
               <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />

--- a/src/pages/Streaming/Songs.vue
+++ b/src/pages/Streaming/Songs.vue
@@ -53,6 +53,7 @@ const handlePlayAll = (): void => {
         clearable
         round
         class="w-40 focus-within:w-56"
+        data-search-input
       >
         <template #prefix>
           <IconLucideSearch class="size-4 text-on-surface-variant/40 shrink-0" />


### PR DESCRIPTION
## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

增加了应用内快捷键「页面内搜索」，在有搜索框的页面（比如歌单页面）聚焦到搜索框。默认快捷键为 `/`。为了操作更流畅统一，输入框可以用 Esc 失焦

## 测试情况

测试有效

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
