### PR TITLE
fix(lyric): 修复 AMLL 引擎的 TTML ruby 注音解析

### DIFF
--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { bestExternalIndex, detectFormat, parseLyric } from "./parse";
+import { parseTTML } from "./parseTTML";
 
 describe("lyric parse", () => {
   it("根据内容识别常见歌词格式", () => {
@@ -79,5 +80,62 @@ describe("lyric parse", () => {
       { startTime: 1_000, endTime: 2_000, word: "B" },
     ]);
     expect(line.endTime).toBe(2_000);
+  });
+
+  it("TTML 逐字 ruby 注音应提取到 LyricWord.ruby，汉字基底不含空字符串", () => {
+    const ttml = [
+      '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling">',
+      '<body><p begin="0" end="1000">',
+      '<span begin="0" end="500">Dai</span> ',
+      '<span begin="200" end="300"><tts:ruby base="行"><tts:ruby:textContainer><tts:ruby:text begin="200" end="250">い</tts:ruby:text></tts:ruby:textContainer></tts:ruby></span>',
+      '<span begin="300" end="400"><tts:ruby base="く"><tts:ruby:textContainer><tts:ruby:text begin="300" end="400">こう</tts:ruby:text></tts:ruby:textContainer></tts:ruby></span>',
+      '</p></body></tt>',
+    ].join("");
+
+    const lines = parseTTML(ttml);
+    expect(lines).toHaveLength(1);
+    const words = lines[0].words;
+
+    // 不应有空的 word 字符串
+    expect(words.some((w) => w.word === "")).toBe(false);
+
+    // 应包含 Dai、行、く 三个非空单词（空格是 XML 源中的分隔符）
+    const wordTexts = words.map((w) => w.word);
+    expect(wordTexts).toEqual(["Dai", " ", "行", "く"]);
+
+    // 汉字基底应正确获取时间戳（来自 ttml:text 的 begin/end）
+    const xing = words.find((w) => w.word === "行");
+    const ku = words.find((w) => w.word === "く");
+    expect(xing).toMatchObject({ startTime: 200_000, endTime: 250_000 });
+    expect(ku).toMatchObject({ startTime: 300_000, endTime: 400_000 });
+  });
+
+  it("TTML 简化格式（span tts:ruby container）应正确提取汉字基底时间戳并跳过注音文本", () => {
+    // 模拟 AMLM 实际格式：<span tts:ruby="container"><span tts:ruby="base">行</span><span tts:ruby="textContainer">...</span></span>
+    const ttml = [
+      '<tt xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling">',
+      '<body><p begin="0" end="1000">',
+      '<span begin="0" end="500">Dai</span> ',
+      '<span tts:ruby="container"><span tts:ruby="base">行</span><span tts:ruby="textContainer"><span tts:ruby="text" begin="200" end="250">い</span></span></span>',
+      '<span tts:ruby="container"><span tts:ruby="base">く,</span><span tts:ruby="textContainer"><span tts:ruby="text" begin="250" end="300">こう</span></span></span>',
+      '</p></body></tt>',
+    ].join("");
+
+    const lines = parseTTML(ttml);
+    expect(lines).toHaveLength(1);
+    const words = lines[0].words;
+
+    // 不应有空字符串单词
+    expect(words.some((w) => w.word === "")).toBe(false);
+
+    // 汉字基底应正确提取，注音文本不应混入
+    const wordTexts = words.map((w) => w.word);
+    expect(wordTexts).toEqual(["Dai", " ", "行", "く,"]);
+
+    // 时间戳应来自 ttml:text 的 begin/end
+    const xing = words.find((w) => w.word === "行");
+    const ku = words.find((w) => w.word === "く,");
+    expect(xing).toMatchObject({ startTime: 200_000, endTime: 250_000 });
+    expect(ku).toMatchObject({ startTime: 250_000, endTime: 300_000 });
   });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -89,7 +89,7 @@ describe("lyric parse", () => {
       '<span begin="0" end="500">Dai</span> ',
       '<span begin="200" end="300"><tts:ruby base="行"><tts:ruby:textContainer><tts:ruby:text begin="200" end="250">い</tts:ruby:text></tts:ruby:textContainer></tts:ruby></span>',
       '<span begin="300" end="400"><tts:ruby base="く"><tts:ruby:textContainer><tts:ruby:text begin="300" end="400">こう</tts:ruby:text></tts:ruby:textContainer></tts:ruby></span>',
-      '</p></body></tt>',
+      "</p></body></tt>",
     ].join("");
 
     const lines = parseTTML(ttml);
@@ -118,7 +118,7 @@ describe("lyric parse", () => {
       '<span begin="0" end="500">Dai</span> ',
       '<span tts:ruby="container"><span tts:ruby="base">行</span><span tts:ruby="textContainer"><span tts:ruby="text" begin="200" end="250">い</span></span></span>',
       '<span tts:ruby="container"><span tts:ruby="base">く,</span><span tts:ruby="textContainer"><span tts:ruby="text" begin="250" end="300">こう</span></span></span>',
-      '</p></body></tt>',
+      "</p></body></tt>",
     ].join("");
 
     const lines = parseTTML(ttml);

--- a/src/utils/lyric/parseTTML.ts
+++ b/src/utils/lyric/parseTTML.ts
@@ -9,6 +9,7 @@
  * - iTunes 翻译元数据（translations 段）
  * - iTunes 音译元数据（transliterations 段，行级 + 逐词罗马音）
  * - 逐字间有意义的空格保留
+ * - ruby 注音（tts:ruby base/text）提取到 LyricWord.ruby
  */
 
 import type { LyricLine, LyricWord } from "@shared/types/lyrics";
@@ -40,13 +41,159 @@ const getWordText = (el: Element): string => {
     if (node.nodeType === Node.TEXT_NODE) {
       text += node.textContent ?? "";
     } else if (node.nodeType === Node.ELEMENT_NODE) {
-      const role = getAttr(node as Element, "role");
-      if (role !== "x-translation" && role !== "x-roman") {
-        text += getWordText(node as Element);
-      }
+      const childEl = node as Element;
+      const role = getAttr(childEl, "role");
+      if (role === "x-translation" || role === "x-roman") continue;
+      // 跳过 ruby 注音 span（文字由 base 节点单独处理）
+      if (getAttr(childEl, "ruby") === "text") continue;
+      text += getWordText(childEl);
     }
   }
   return text;
+};
+
+/**
+ * 预处理 tts:ruby 注音元素，统一转换为带时间戳的 <span> 结构
+ *
+ * 支持两种格式：
+ * 1. 标准 TTML：<tts:ruby base="行"><tts:ruby:textContainer><tts:ruby:text begin="...">い</tts:ruby:text></tts:ruby:textContainer></tts:ruby>
+ * 2. 简化格式：<span tts:ruby="container"><span tts:ruby="base">行</span><span tts:ruby="textContainer"><span tts:ruby="text" begin="..." end="...">い</span></span></span>
+ *
+ * 转换后：
+ * - 格式1 → <span tts:ruby="base" begin="..." end="...">行</span><span tts:ruby="text" begin="..." end="...">い</span>
+ * - 格式2 → <span tts:ruby="base" begin="..." end="...">行</span><span tts:ruby="text" begin="..." end="...">い</span>
+ * 两者统一，base 获得时间戳，text span 紧跟其后，供 collectRubySegments 收集。
+ */
+/** @internal 供测试使用 */
+export const normalizeRubyElements = (el: Element): void => {
+  const queue: Element[] = [el];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    // 收集所有子元素快照，避免修改 DOM 时迭代问题
+    const children = Array.from(current.children);
+    for (const child of children) {
+      // 格式1：处理 <tts:ruby base="..."> 容器（在 happy-dom 中 localName="ruby"）
+      if (child.localName === "ruby") {
+        const baseText = getAttr(child, "base") ?? "";
+        const rubySegments: { begin: string; end: string; text: string }[] = [];
+        for (const subChild of Array.from(child.children)) {
+          if (subChild.tagName.toLowerCase() !== "tts:ruby:textcontainer") continue;
+          for (const textEl of Array.from(subChild.children)) {
+            if (textEl.tagName.toLowerCase() !== "tts:ruby:text") continue;
+            const b = getAttr(textEl, "begin");
+            const e = getAttr(textEl, "end");
+            const t = (textEl.textContent ?? "").trim();
+            if (t) rubySegments.push({ begin: b ?? "", end: e ?? "", text: t });
+          }
+        }
+        const parent = child.parentElement;
+        if (!parent) {
+          // 已脱离 DOM，从队列中移除并跳出内层循环，防止死循环
+          queue.shift();
+          break;
+        }
+        const toInsert: Element[] = [];
+        const baseSpan = parent.ownerDocument.createElement("span");
+        baseSpan.setAttribute("tts:ruby", "base");
+        baseSpan.textContent = baseText;
+        if (rubySegments.length) {
+          baseSpan.setAttribute("begin", rubySegments[0].begin);
+          baseSpan.setAttribute("end", rubySegments[0].end);
+        }
+        toInsert.push(baseSpan);
+        for (const seg of rubySegments) {
+          const textSpan = parent.ownerDocument.createElement("span");
+          textSpan.setAttribute("tts:ruby", "text");
+          textSpan.textContent = seg.text;
+          if (seg.begin) textSpan.setAttribute("begin", seg.begin);
+          if (seg.end) textSpan.setAttribute("end", seg.end);
+          toInsert.push(textSpan);
+        }
+        const ref = child.nextSibling;
+        for (const el of toInsert) {
+          parent.insertBefore(el, ref);
+        }
+        parent.removeChild(child);
+        // 已展开，不加入队列
+        continue;
+      }
+      // 格式2：处理 <span tts:ruby="container">...</span>
+      if (child.localName === "span" && getAttr(child, "ruby") === "container") {
+        const baseSpan = Array.from(child.children).find(
+          (c) => c.localName === "span" && getAttr(c, "ruby") === "base",
+        );
+        const textContainer = Array.from(child.children).find(
+          (c) => c.localName === "span" && getAttr(c, "ruby") === "textContainer",
+        );
+        if (!baseSpan || !textContainer) {
+          // 结构不完整，从队列中移除并跳过，防止死循环
+          queue.shift();
+          break;
+        }
+        const baseText = (baseSpan.textContent ?? "").trim();
+        const rubySegments: { begin: string; end: string; text: string }[] = [];
+        for (const textEl of Array.from(textContainer.children)) {
+          if (textEl.localName !== "span" || getAttr(textEl, "ruby") !== "text") continue;
+          const b = getAttr(textEl, "begin");
+          const e = getAttr(textEl, "end");
+          const t = (textEl.textContent ?? "").trim();
+          if (t) rubySegments.push({ begin: b ?? "", end: e ?? "", text: t });
+        }
+        const parent = child.parentElement;
+        if (!parent) break;
+        const toInsert: Element[] = [];
+        const newBase = parent.ownerDocument.createElement("span");
+        newBase.setAttribute("tts:ruby", "base");
+        newBase.textContent = baseText;
+        if (rubySegments.length) {
+          newBase.setAttribute("begin", rubySegments[0].begin);
+          newBase.setAttribute("end", rubySegments[0].end);
+        }
+        toInsert.push(newBase);
+        for (const seg of rubySegments) {
+          const textSpan = parent.ownerDocument.createElement("span");
+          textSpan.setAttribute("tts:ruby", "text");
+          textSpan.textContent = seg.text;
+          if (seg.begin) textSpan.setAttribute("begin", seg.begin);
+          if (seg.end) textSpan.setAttribute("end", seg.end);
+          toInsert.push(textSpan);
+        }
+        const ref = child.nextSibling;
+        for (const el of toInsert) {
+          parent.insertBefore(el, ref);
+        }
+        parent.removeChild(child);
+        // 已展开，不加入队列
+        continue;
+      }
+      // 非 ruby 元素，加入队列继续处理
+      queue.push(child);
+    }
+  }
+};
+
+/**
+ * 收集紧跟在 base span 后的相邻 tts:ruby="text" span 作为注音
+ * @param afterBase 紧跟在 base span 后的第一个 sibling
+ * @returns ruby 注音段数组，无注音时返回 undefined
+ */
+const collectRubySegments = (afterBase: Element | null): LyricWord["ruby"] => {
+  const segments: LyricWord["ruby"] = [];
+  let cur = afterBase;
+  while (cur && getAttr(cur, "ruby") === "text") {
+    const b = getAttr(cur, "begin");
+    const e = getAttr(cur, "end");
+    const text = (cur.textContent ?? "").trim();
+    if (text) {
+      segments.push({
+        startTime: b ? parseTTMLTime(b) : 0,
+        endTime: e ? parseTTMLTime(e) : 0,
+        word: text,
+      });
+    }
+    cur = cur.nextElementSibling;
+  }
+  return segments.length > 0 ? segments : undefined;
 };
 
 /**
@@ -316,6 +463,9 @@ export const parseTTML = (text: string, preferredLang = ""): LyricLine[] => {
     throw new Error("Invalid TTML XML");
   }
 
+  // 预处理：将 <tts:ruby base="漢字"> 展开为带时间的 <span tts:ruby="base">漢字</span>
+  normalizeRubyElements(doc.documentElement);
+
   const { mainAgent, agentTypes } = collectAgents(doc);
   const translations = collectTranslations(doc, preferredLang);
   const transliterations = collectTransliterations(doc);
@@ -393,6 +543,7 @@ export const parseTTML = (text: string, preferredLang = ""): LyricLine[] => {
         const span = node as Element;
         if (span.localName !== "span") continue;
         const role = getAttr(span, "role");
+        const rubyRole = getAttr(span, "ruby");
 
         if (role === "x-bg") {
           // 背景歌词行，递归解析
@@ -407,20 +558,41 @@ export const parseTTML = (text: string, preferredLang = ""): LyricLine[] => {
         } else if (role === "x-roman") {
           // 行内音译
           if (!line.romanLyric) line.romanLyric = span.textContent?.trim() ?? "";
+        } else if (rubyRole === "text") {
+          // 孤立的天文字 span，跳过（已由 base 收集）
+          continue;
         } else {
           // 逐字 span
           const wb = getAttr(span, "begin");
           const we = getAttr(span, "end");
-          if (wb && we) {
-            const lyricWord: LyricWord = {
-              word: getWordText(span),
-              startTime: parseTTMLTime(wb),
-              endTime: parseTTMLTime(we),
-            };
-            line.words.push(lyricWord);
-            timedWords.push(lyricWord);
-            lastWasTimedSpan = true;
-          }
+
+          // 检查 span 是否包含 ruby base 子元素（标准 TTML 格式展开后的结构）
+          const rubyBaseChild = Array.from(span.children).find(
+            (c) => c.localName === "span" && getAttr(c, "ruby") === "base",
+          );
+          const rubyBaseTime = rubyBaseChild
+            ? {
+                startTime: rubyBaseChild.getAttribute("begin") ? parseTTMLTime(rubyBaseChild.getAttribute("begin")!) : 0,
+                endTime: rubyBaseChild.getAttribute("end") ? parseTTMLTime(rubyBaseChild.getAttribute("end")!) : 0,
+              }
+            : null;
+
+          // 收集 base span 后紧跟的 text 注音（简化格式展开后的结构）
+          const rubySegments = rubyRole === "base" ? collectRubySegments(span.nextElementSibling) : undefined;
+
+          // 优先使用 ruby base 的时间戳（来自 ttml:text），否则使用 span 自己的时间戳
+          const effectiveBegin = rubyBaseTime?.startTime ?? (wb ? parseTTMLTime(wb) : 0);
+          const effectiveEnd = rubyBaseTime?.endTime ?? (we ? parseTTMLTime(we) : 0);
+
+          const lyricWord: LyricWord = {
+            word: getWordText(span),
+            startTime: effectiveBegin,
+            endTime: effectiveEnd,
+            ruby: rubySegments,
+          };
+          line.words.push(lyricWord);
+          timedWords.push(lyricWord);
+          lastWasTimedSpan = true;
         }
       }
     }

--- a/src/utils/lyric/parseTTML.ts
+++ b/src/utils/lyric/parseTTML.ts
@@ -572,13 +572,18 @@ export const parseTTML = (text: string, preferredLang = ""): LyricLine[] => {
           );
           const rubyBaseTime = rubyBaseChild
             ? {
-                startTime: rubyBaseChild.getAttribute("begin") ? parseTTMLTime(rubyBaseChild.getAttribute("begin")!) : 0,
-                endTime: rubyBaseChild.getAttribute("end") ? parseTTMLTime(rubyBaseChild.getAttribute("end")!) : 0,
+                startTime: rubyBaseChild.getAttribute("begin")
+                  ? parseTTMLTime(rubyBaseChild.getAttribute("begin")!)
+                  : 0,
+                endTime: rubyBaseChild.getAttribute("end")
+                  ? parseTTMLTime(rubyBaseChild.getAttribute("end")!)
+                  : 0,
               }
             : null;
 
           // 收集 base span 后紧跟的 text 注音（简化格式展开后的结构）
-          const rubySegments = rubyRole === "base" ? collectRubySegments(span.nextElementSibling) : undefined;
+          const rubySegments =
+            rubyRole === "base" ? collectRubySegments(span.nextElementSibling) : undefined;
 
           // 优先使用 ruby base 的时间戳（来自 ttml:text），否则使用 span 自己的时间戳
           const effectiveBegin = rubyBaseTime?.startTime ?? (wb ? parseTTMLTime(wb) : 0);


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

<!-- 这个 PR 做了什么、为什么这么做（动机 + 主要变更），尽量描述清楚 -->

我制作了一个 TTML 歌词，已提交到 `amll-ttml-db`，再回头播放这首歌发现 AMLL 引擎没法渲染其中的某些日文（用 ruby 注音），本 pr 就是对此进行的修改（仅面向 AMLL 引擎）

## 测试情况

<!-- 如何验证这些改动？手动复现步骤、覆盖到的平台（Windows / macOS / Linux）等 -->

本地测试 见下图


## 截图 / 录屏

<!-- 涉及 UI 改动请附上；无则可删除本节 -->

<img width="1923" height="1206" alt="image" src="https://github.com/user-attachments/assets/fe9a5c1b-e743-42d4-8f4e-1e419318f776" />



## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
