### PR TITLE
feat(auth): 实现每日签到功能及签到状态展示

### DIFF
--- a/electron/main/apis/netease/index.ts
+++ b/electron/main/apis/netease/index.ts
@@ -50,6 +50,8 @@ const NON_CACHEABLE: ReadonlySet<string> = new Set([
   "playlist_detail",
   "user_playlist",
   "user_subcount",
+  "daily_signin",
+  "signin_progress",
   "user_cloud",
   "user_cloud_del",
   "cloud_upload_check",

--- a/electron/main/apis/netease/modules/daily_signin.ts
+++ b/electron/main/apis/netease/modules/daily_signin.ts
@@ -1,0 +1,13 @@
+/**
+ * 每日签到（0=安卓端得 3 经验，1=web/PC 端得 2 经验）
+ * 成功 `{android: {point: 3, code: 200}, web: {point: 2, code: 200}}`，
+ * 重复签到 / 未登录时对应 code 为 -2 / 301
+ */
+
+import { createOption } from "../core/option";
+import type { NeteaseModule } from "../core/types";
+
+const dailySignin: NeteaseModule = (query, request) =>
+  request("/api/point/dailyTask", { type: query.type || 0 }, createOption(query, "weapi"));
+
+export default dailySignin;

--- a/electron/main/apis/netease/modules/index.ts
+++ b/electron/main/apis/netease/modules/index.ts
@@ -38,6 +38,8 @@ import user_level from "./user_level";
 import user_playlist from "./user_playlist";
 import user_record from "./user_record";
 import user_subcount from "./user_subcount";
+import daily_signin from "./daily_signin";
+import signin_progress from "./signin_progress";
 
 // 搜索
 import cloudsearch from "./cloudsearch";
@@ -132,6 +134,8 @@ export const modules: Record<string, NeteaseModule> = {
   user_playlist,
   user_record,
   user_subcount,
+  daily_signin,
+  signin_progress,
 
   cloudsearch,
   search,

--- a/electron/main/apis/netease/modules/signin_progress.ts
+++ b/electron/main/apis/netease/modules/signin_progress.ts
@@ -1,0 +1,15 @@
+/**
+ * 签到进度（连续签到天数、目标天数等）
+ */
+
+import { createOption } from "../core/option";
+import type { NeteaseModule } from "../core/types";
+
+const signinProgress: NeteaseModule = (query, request) =>
+  request(
+    "/api/act/modules/signin/v2/progress",
+    { moduleId: query.moduleId || "1207signin-1207signin" },
+    createOption(query, "weapi"),
+  );
+
+export default signinProgress;

--- a/shared/utils/track.ts
+++ b/shared/utils/track.ts
@@ -1,6 +1,6 @@
 import type { Artist } from "../types/player";
 
-/** 
+/**
  * 获取有效的歌手记录
  * @param artists - 歌手数组
  * @returns 过滤掉 name 为空的歌手记录

--- a/src/apis/user/netease.ts
+++ b/src/apis/user/netease.ts
@@ -73,3 +73,64 @@ export const fetchUserLevel = async (): Promise<number | undefined> => {
   const level = body?.data?.level;
   return typeof level === "number" ? level : undefined;
 };
+
+interface SigninBody {
+  android?: { code?: number; point?: number; msg?: string };
+  web?: { code?: number; point?: number; msg?: string };
+  code?: number;
+  point?: number;
+  msg?: string;
+}
+
+/**
+ * 每日签到
+ * @param type 签到类型（0=安卓端得 3 经验，1=PC 端得 2 经验）
+ * @returns 本次获得的经验；重复签到 / 未登录等失败时抛带 code 的 Error
+ */
+export const dailySignin = async (type: 0 | 1 = 1): Promise<{ point: number }> => {
+  let body: SigninBody;
+  try {
+    body = await neteaseApi.daily_signin<SigninBody>({ type });
+  } catch (err) {
+    // 顶层 code 形态的失败响应（如 {code: -2}）由请求层抛出，这里统一为带 code 的 Error
+    const apiErr = err as { body?: { code?: number; msg?: string } };
+    const e = new Error(apiErr?.body?.msg || "signin failed") as Error & { code?: number };
+    e.code = apiErr?.body?.code;
+    throw e;
+  }
+  // 兼容 `{android, web}` 与顶层 `{code, point}` 两种响应形态
+  const result = body?.web ?? body?.android ?? body;
+  if (result?.code === 200) return { point: result.point ?? 0 };
+  const err = new Error(result?.msg || "signin failed") as Error & { code?: number };
+  err.code = result?.code;
+  throw err;
+};
+
+/**
+ * 签到状态（今日是否已签到 + 连续天数）
+ */
+export interface SigninStatus {
+  /** 今日是否已签到（接口未明确时为 undefined，由本地记录兜底） */
+  signed?: boolean;
+  /** 连续签到天数 */
+  days?: number;
+}
+
+/**
+ * 拉取签到状态
+ * @returns 今日签到状态与连续天数；接口不可用或结构不符时对应字段为 undefined
+ */
+export const fetchSigninStatus = async (): Promise<SigninStatus> => {
+  const body = await neteaseApi.signin_progress<{
+    data?: {
+      signinInfo?: { signinStatus?: number; todayFirstSigninStatus?: number };
+      signinProgress?: { signinDays?: number };
+    };
+  }>();
+  const info = body?.data?.signinInfo ?? {};
+  const days = body?.data?.signinProgress?.signinDays;
+  return {
+    signed: info.signinStatus === 1 || info.todayFirstSigninStatus === 1 ? true : undefined,
+    days: typeof days === "number" ? days : undefined,
+  };
+};

--- a/src/components/layout/NavUser.vue
+++ b/src/components/layout/NavUser.vue
@@ -2,10 +2,12 @@
 import { useUserStore } from "@/stores/user";
 import { dialog } from "@/composables/useDialog";
 import { toast } from "@/composables/useToast";
+import { dailySignin, fetchSigninStatus } from "@/apis/user/netease";
 import vipImg from "@/assets/images/vip.png";
 import IconLucideListMusic from "~icons/lucide/list-music";
 import IconLucideDisc3 from "~icons/lucide/disc-3";
 import IconLucideUserRound from "~icons/lucide/user-round";
+import IconLucideDatabase from "~icons/lucide/database";
 
 const { t } = useI18n();
 const router = useRouter();
@@ -13,12 +15,55 @@ const user = useUserStore();
 
 const loginOpen = ref(false);
 const popoverOpen = ref(false);
+const signinLoading = ref(false);
+/** 今日是否已签到 */
+const signed = ref(false);
+/** 连续签到天数（签到进度接口不可用时为 undefined，隐藏徽章） */
+const signinDays = ref<number>();
+
+/** 本地签到日期记录 key（值为 YYYY-MM-DD，跨天自动失效） */
+const SIGNIN_DATE_KEY = "splayer/netease-signin-date";
+
+/** 本地日期字符串（YYYY-MM-DD） */
+const todayStr = (): string => {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate(),
+  ).padStart(2, "0")}`;
+};
+
+/** 写入/清除本地签到记录 */
+const persistSigned = (): void => {
+  localStorage.setItem(SIGNIN_DATE_KEY, todayStr());
+};
+
+/** 本地记录今天已签到（接口拿不到状态时兜底） */
+const locallySigned = (): boolean => localStorage.getItem(SIGNIN_DATE_KEY) === todayStr();
+
+/** 拉取签到状态（今日签到 + 连续天数），失败时静默保留旧值 */
+const refreshSigninStatus = async (): Promise<void> => {
+  try {
+    const status = await fetchSigninStatus();
+    if (status.signed === true) signed.value = true;
+    if (status.days !== undefined) signinDays.value = status.days;
+  } catch {
+    // 状态仅为展示性信息，失败不打扰用户
+  }
+};
 
 /** 启动时校验登录态（cookie 仍有效就刷新 profile） */
 onMounted(() => {
   if (user.profile) {
     user.fetchStatus().catch(() => undefined);
   }
+});
+
+/** 每次展开面板时重置签到状态，再以本地记录 + 接口为准 */
+watch(popoverOpen, (open) => {
+  if (!open || !user.isLoggedIn) return;
+  signed.value = false;
+  if (locallySigned()) signed.value = true;
+  refreshSigninStatus();
 });
 
 const isVip = computed(() => !!user.profile?.vipType && user.profile.vipType !== 0);
@@ -54,6 +99,32 @@ const onTriggerClick = (): void => {
 const handleStatClick = (key: "playlist" | "album" | "artist"): void => {
   popoverOpen.value = false;
   router.push({ path: "/favorites", query: { tab: key } });
+};
+
+const handleSignin = async (): Promise<void> => {
+  if (signinLoading.value) return;
+  signinLoading.value = true;
+  try {
+    const { point } = await dailySignin(1);
+    toast.success(t("login.signinSuccess", { point }));
+    signed.value = true;
+    persistSigned();
+    refreshSigninStatus();
+  } catch (err) {
+    const code = (err as Error & { code?: number }).code;
+    if (code === -2) {
+      // 服务端确认今日已签到
+      toast.info(t("login.signinRepeat"));
+      signed.value = true;
+      persistSigned();
+    } else if (code === 301) {
+      toast.warning(t("login.signinNeedLogin"));
+    } else {
+      toast.error(t("login.signinFailed"));
+    }
+  } finally {
+    signinLoading.value = false;
+  }
 };
 
 const handleLogout = async (): Promise<void> => {
@@ -159,6 +230,23 @@ const handleLogout = async (): Promise<void> => {
         </div>
       </div>
       <SDivider class="w-full" />
+      <SButton
+        variant="secondary"
+        size="small"
+        block
+        :loading="signinLoading"
+        :disabled="signed"
+        @click="handleSignin"
+      >
+        <template #icon><IconLucideDatabase /></template>
+        {{ signed ? t("login.signed") : t("login.signin") }}
+        <span
+          v-if="signinDays !== undefined"
+          class="ml-0.5 inline-flex items-center px-1 py-0.5 rounded-md bg-primary/15 text-primary text-[10px] font-semibold leading-none tabular-nums"
+        >
+          {{ signinDays }}
+        </span>
+      </SButton>
       <SButton variant="secondary" size="small" block @click="handleLogout">
         <template #icon><IconLucideLogOut /></template>
         {{ t("login.logout") }}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -343,7 +343,13 @@
     "logout": "Sign out",
     "logoutConfirmTitle": "Sign out",
     "logoutConfirmDesc": "Sign out of the current account?",
-    "logoutDone": "Signed out"
+    "logoutDone": "Signed out",
+    "signin": "Daily check-in",
+    "signed": "Checked in",
+    "signinSuccess": "Checked in, +{point} XP",
+    "signinRepeat": "Already checked in today",
+    "signinNeedLogin": "Session expired, sign in again",
+    "signinFailed": "Check-in failed, try again later"
   },
   "search": {
     "title": "Search",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -331,7 +331,13 @@
     "logout": "退出登录",
     "logoutConfirmTitle": "退出登录",
     "logoutConfirmDesc": "确认退出当前账号？",
-    "logoutDone": "已退出登录"
+    "logoutDone": "已退出登录",
+    "signin": "签到",
+    "signed": "已签到",
+    "signinSuccess": "签到成功，经验 +{point}",
+    "signinRepeat": "今日已签到",
+    "signinNeedLogin": "登录已失效，请重新登录",
+    "signinFailed": "签到失败，请稍后重试"
   },
   "search": {
     "title": "搜索",

--- a/windows/desktop-lyric/App.vue
+++ b/windows/desktop-lyric/App.vue
@@ -77,9 +77,7 @@ const placeholder = (key: string, mainText: string, subText?: string): DisplayIt
 };
 
 /** 艺术家显示文本 */
-const artistsText = computed<string>(
-  () => formatArtists(track.value?.artists) || "未知艺术家",
-);
+const artistsText = computed<string>(() => formatArtists(track.value?.artists) || "未知艺术家");
 
 /** 实际渲染的歌词列表 */
 const displayItems = computed<DisplayItem[]>(() => {

--- a/windows/dynamic-island/App.vue
+++ b/windows/dynamic-island/App.vue
@@ -79,9 +79,7 @@ const measureTextWidth = (text: string, sizePx: number = fontSize.value): number
 };
 
 /* 艺术家显示文本 */
-const artistsText = computed<string>(
-  () => formatArtists(track.value?.artists) || "未知艺术家",
-);
+const artistsText = computed<string>(() => formatArtists(track.value?.artists) || "未知艺术家");
 
 /* 当前行 */
 const currentLine = computed<LyricLine | null>(() => {

--- a/windows/taskbar-lyric/App.vue
+++ b/windows/taskbar-lyric/App.vue
@@ -125,9 +125,7 @@ const currentLine = computed<LyricLine | null>(() => {
 const hasLyric = computed(() => lyric.value.length > 0 && primaryIndex.value >= 0);
 
 const titleText = computed<string>(() => track.value?.title ?? "SPlayer Next");
-const artistsText = computed<string>(
-  () => formatArtists(track.value?.artists) || "未知艺术家",
-);
+const artistsText = computed<string>(() => formatArtists(track.value?.artists) || "未知艺术家");
 
 const effectiveTheme = computed<"light" | "dark">(() => {
   if (config.colorMode === "light") return "light";


### PR DESCRIPTION
- 新增每日签到 API 模块及签到进度模块
- 接口层封装 dailySignin 和 fetchSigninStatus 方法，支持签到及状态查询
- UI 层在导航用户组件添加签到按钮及签到状态展示
- 本地持久化保存当天签到状态，接口失败时可兜底
- 添加多语言支持（中英文）相关签到文案
- 签到成功、重复签到、未登录等状态均给出对应提示信息
- 签到按钮支持加载态及禁用逻辑，避免重复点击

<img width="414" height="750" alt="image" src="https://github.com/user-attachments/assets/60e8ec5d-98fa-401d-bd29-b981e8fc5f73" />
