### PR TITLE
fix: 修复网易云听歌打卡上报参数

### DIFF
--- a/electron/main/apis/netease/core/ncbl.ts
+++ b/electron/main/apis/netease/core/ncbl.ts
@@ -1,6 +1,7 @@
 import { randomBytes, randomUUID as cryptoRandomUUID } from "node:crypto";
 import * as zlib from "node:zlib";
 import { CLIENT_LOG3_DOMAIN } from "./config";
+import { createPlaybackLogContext } from "./playLog";
 import { fetchWithProxy } from "@main/utils/proxy";
 
 interface NeteaseLogRecord {
@@ -41,22 +42,6 @@ interface NcblContext {
   };
   startTime: number;
   processId: number;
-}
-
-interface NcblSong {
-  id: number;
-  name: string;
-  artist: string;
-  bitrate: number;
-  level: string;
-  vip: boolean;
-  time: number;
-}
-
-interface NcblSource {
-  id: string;
-  type: string;
-  name: string;
 }
 
 interface UploadResult {
@@ -224,143 +209,42 @@ const buildRecord = ({ time, action, data }: NeteaseLogRecord): string => {
 export const buildRecords = (records: NeteaseLogRecord[]): string =>
   records.map(buildRecord).join("");
 
-export const buildPlv = (
-  ctx: NcblContext,
-  song: NcblSong,
-  source: NcblSource,
-): Record<string, unknown> => {
-  const now = Date.now();
+export const extractContext = (cookieObj: Record<string, string>): NcblContext => {
+  const playbackLog = createPlaybackLogContext(cookieObj);
   return {
-    mode: "circulation",
-    download: 0,
-    alg: "",
-    status: "front",
-    id: String(song.id),
-    bitrate: song.bitrate,
-    type: "song",
-    is_listentogether: 0,
-    source: source.name,
-    is_heart: 0,
-    resource_ratio: "",
-    resource_time: song.time,
-    musiceffect_id: "",
-    app_mode: 2,
-    bitrate_level: song.level,
-    _addrefer: `[F:63][${now}#933#${ctx.app.version}#${ctx.app.versionCode}#c9156c3][e][2][23][cell_pc_songlist_song:2|page_pc_songlist_songflow|page_mine_like_music][${song.id}:song:x:x|:::|${source.id}:list::]`,
-    _multirefers: [
-      "[F:26][s][18][_ai]",
-      "[F:26][s][12][_ai]",
-      `[F:63][${now}#933#${ctx.app.version}#${ctx.app.versionCode}#c9156c3][e][2][8][cell_pc_main_tab_entrance:6|page_pc_main_tab][我喜欢的音乐:spm::|:::]`,
-      "[F:26][s][5][_ai]",
-      "[F:26][s][0][_ai]",
-    ],
-    vipType: ctx.auth.vipType,
-    fee: 1,
-    file: 4,
-    rightSource: 0,
-    sourceId: source.id,
-    sourcetype: source.type,
-    libra_abt: "",
-    channel: ctx.app.channel,
-    curStartChannel: "",
+    app: {
+      id: cookieObj.appid || "",
+      urs: "",
+      pid: "",
+      nsm: cookieObj.WEVNSM || "1.0.0",
+      cid: cookieObj.WNMCID || `${randomBytes(3).toString("hex")}.${Date.now()}.01.0`,
+      channel: playbackLog.app.channel,
+      version: playbackLog.app.version,
+      versionCode: playbackLog.app.versionCode,
+      buildCode: cookieObj.buildver || "",
+      buildType: "release",
+      packageId: "",
+    },
+    device: {
+      id: cookieObj.deviceId || cookieObj.sDeviceId || "",
+      ti: cookieObj.NMTID || "",
+      sign: cookieObj.clientSign || "",
+      model: cookieObj.mode || cookieObj.mobilename || "",
+      nnid: cookieObj._ntes_nnid || ",",
+      nuid: cookieObj._ntes_nuid || "",
+      csrf: cookieObj.__csrf || "",
+      systemType: cookieObj.os || "pc",
+      systemVersion: cookieObj.osver || "Microsoft-Windows-10-Professional-build-19045-64bit",
+    },
+    auth: {
+      token: cookieObj.MUSIC_U || "",
+      sessionId: cookieObj["JSESSIONID-WYYY"] || "",
+      vipType: playbackLog.auth.vipType,
+    },
+    startTime: Date.now(),
+    processId: Math.floor(Math.random() * 90000) + 10000,
   };
 };
-
-export const buildPld = (
-  ctx: NcblContext,
-  song: NcblSong,
-  source: NcblSource,
-  played: number,
-): Record<string, unknown> => {
-  const now = Date.now();
-  return {
-    mode: "circulation",
-    download: 0,
-    alg: "",
-    status: "front",
-    id: String(song.id),
-    time: played,
-    type: "song",
-    is_listentogether: 0,
-    source: source.name,
-    is_heart: 0,
-    realtime: played,
-    resource_ratio: "",
-    resource_time: song.time,
-    musiceffect_id: "1001",
-    app_mode: 1,
-    lyriceffect: "default",
-    displayMode: "classic",
-    bitrate: song.bitrate,
-    bitrate_level: song.level,
-    _addrefer: `[F:63][${now}#616#${ctx.app.version}#${ctx.app.versionCode}#c9156c3][e][2][92][btn_pc_cover_play|cell_pc_songlist_song:6|page_pc_songlist_songflow|page_mine_like_music][:::|${song.id}:song:x:x|:::|${source.id}:list::]`,
-    _multirefers: [
-      "[F:26][s][87][_ai]",
-      "[F:26][s][81][_ai]",
-      "[F:26][s][75][_ai]",
-      "[F:26][s][69][_ai]",
-      "[F:26][s][63][_ai]",
-    ],
-    vipType: ctx.auth.vipType,
-    fee: 8,
-    file: 4,
-    rightSource: 0,
-    sourceId: source.id,
-    sourcetype: source.type,
-    end: "interrupt",
-    libra_abt: "",
-    channel: ctx.app.channel,
-    curStartChannel: "",
-  };
-};
-
-export const parseCookie = (cookie: unknown): Record<string, string> => {
-  if (cookie && typeof cookie === "object") return cookie as Record<string, string>;
-  if (typeof cookie !== "string") return {};
-  const obj: Record<string, string> = {};
-  for (const part of cookie.split(";")) {
-    const idx = part.indexOf("=");
-    if (idx <= 0) continue;
-    const key = part.substring(0, idx).trim();
-    const val = part.substring(idx + 1).trim();
-    if (key) obj[key] = val;
-  }
-  return obj;
-};
-
-export const extractContext = (cookieObj: Record<string, string>): NcblContext => ({
-  app: {
-    id: cookieObj.appid || "",
-    urs: "",
-    pid: "",
-    nsm: cookieObj.WEVNSM || "1.0.0",
-    cid: cookieObj.WNMCID || `${randomBytes(3).toString("hex")}.${Date.now()}.01.0`,
-    channel: cookieObj.channel || "netease",
-    version: cookieObj.appver || "3.1.35",
-    versionCode: cookieObj.versioncode || "205293",
-    buildCode: cookieObj.buildver || "",
-    buildType: "release",
-    packageId: "",
-  },
-  device: {
-    id: cookieObj.deviceId || cookieObj.sDeviceId || "",
-    ti: cookieObj.NMTID || "",
-    sign: cookieObj.clientSign || "",
-    model: cookieObj.mode || cookieObj.mobilename || "",
-    nnid: cookieObj._ntes_nnid || ",",
-    nuid: cookieObj._ntes_nuid || "",
-    csrf: cookieObj.__csrf || "",
-    systemType: cookieObj.os || "pc",
-    systemVersion: cookieObj.osver || "Microsoft-Windows-10-Professional-build-19045-64bit",
-  },
-  auth: {
-    token: cookieObj.MUSIC_U || "",
-    sessionId: cookieObj["JSESSIONID-WYYY"] || "",
-    vipType: cookieObj.vipType || "",
-  },
-  startTime: Date.now(),
-  processId: Math.floor(Math.random() * 90000) + 10000,
-});
 
 const randomHexId = (): string => cryptoRandomUUID().replace(/-/g, "");
 

--- a/electron/main/apis/netease/core/playLog.test.ts
+++ b/electron/main/apis/netease/core/playLog.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildPld, buildPlv, createPlaybackLogContext, toNcblSourceType } from "./playLog";
+
+const context = createPlaybackLogContext({});
+const song = {
+  id: 123,
+  type: "song" as const,
+  name: "测试歌曲",
+  artist: "测试歌手",
+  bitrate: 320,
+  level: "exhigh",
+  fee: 1,
+  time: 180,
+};
+
+describe("网易云 NCBL 播放日志", () => {
+  const sourceCases = [
+    ["song", "song", "track"],
+    ["song", "list", "list"],
+    ["song", "album", "album"],
+    ["song", "artist", "artist"],
+    ["dj", "radio", "djradio"],
+  ] as const;
+
+  for (const [resourceType, sourceType, expected] of sourceCases) {
+    it(`将 ${resourceType} 资源的 ${sourceType} 来源映射为 ${expected}`, () => {
+      assert.equal(toNcblSourceType(resourceType, sourceType), expected);
+    });
+  }
+
+  it("歌单与专辑保留来源 ID、类型和真实 fee", () => {
+    const plv = buildPlv(context, song, { id: "456", type: "list", name: "list" });
+    const pld = buildPld(context, song, { id: "999", type: "album", name: "album" }, 60);
+    assert.deepEqual(
+      {
+        id: plv.id,
+        sourceId: plv.sourceId,
+        sourcetype: plv.sourcetype,
+        fee: plv.fee,
+      },
+      { id: "123", sourceId: "456", sourcetype: "list", fee: 1 },
+    );
+    assert.deepEqual(
+      {
+        sourceId: pld.sourceId,
+        sourcetype: pld.sourcetype,
+        fee: pld.fee,
+      },
+      { sourceId: "999", sourcetype: "album", fee: 1 },
+    );
+    assert.equal("_addrefer" in plv, false);
+    assert.equal("_multirefers" in pld, false);
+  });
+
+  it("声音以节目 ID 和 dj 类型写入日志", () => {
+    const voice = {
+      ...song,
+      id: 3081133072,
+      type: "dj" as const,
+      categoryId: 7,
+    };
+    const source = { id: "9988", type: "djradio", name: "djradio" };
+
+    for (const log of [buildPlv(context, voice, source), buildPld(context, voice, source, 60)]) {
+      assert.deepEqual(
+        {
+          id: log.id,
+          type: log.type,
+          sourceId: log.sourceId,
+          sourcetype: log.sourcetype,
+          categoryId: log.categoryId,
+        },
+        {
+          id: "3081133072",
+          type: "dj",
+          sourceId: "9988",
+          sourcetype: "djradio",
+          categoryId: 7,
+        },
+      );
+    }
+  });
+});

--- a/electron/main/apis/netease/core/playLog.ts
+++ b/electron/main/apis/netease/core/playLog.ts
@@ -1,0 +1,136 @@
+interface PlaybackLogContext {
+  app: {
+    channel: string;
+    version: string;
+    versionCode: string;
+  };
+  auth: {
+    vipType: string;
+  };
+}
+
+export interface PlaybackLogResource {
+  id: number;
+  type: "song" | "dj";
+  categoryId?: number;
+  name: string;
+  artist: string;
+  bitrate: number;
+  level: string;
+  fee: number;
+  time: number;
+}
+
+interface PlaybackLogSource {
+  id: string;
+  type: string;
+  name: string;
+}
+
+export const parseCookie = (cookie: unknown): Record<string, string> => {
+  if (cookie && typeof cookie === "object") return cookie as Record<string, string>;
+  if (typeof cookie !== "string") return {};
+  const obj: Record<string, string> = {};
+  for (const part of cookie.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx <= 0) continue;
+    const key = part.substring(0, idx).trim();
+    const val = part.substring(idx + 1).trim();
+    if (key) obj[key] = val;
+  }
+  return obj;
+};
+
+export const createPlaybackLogContext = (
+  cookieObj: Record<string, string>,
+): PlaybackLogContext => ({
+  app: {
+    channel: cookieObj.channel || "netease",
+    version: cookieObj.appver || "3.1.37",
+    versionCode: cookieObj.versioncode || "205354",
+  },
+  auth: {
+    vipType: cookieObj.vipType || "",
+  },
+});
+
+export const toNcblSourceType = (resourceType: "song" | "dj", sourceType: string): string => {
+  if (resourceType === "dj") return "djradio";
+  if (sourceType === "song") return "track";
+  if (sourceType === "radio") return "djradio";
+  return sourceType;
+};
+
+export const buildPlv = (
+  ctx: PlaybackLogContext,
+  resource: PlaybackLogResource,
+  source: PlaybackLogSource,
+): Record<string, unknown> => ({
+  mode: "circulation",
+  download: 0,
+  alg: "",
+  status: "front",
+  id: String(resource.id),
+  bitrate: resource.bitrate,
+  type: resource.type,
+  ...(resource.type === "dj" && resource.categoryId !== undefined
+    ? { categoryId: resource.categoryId }
+    : {}),
+  is_listentogether: 0,
+  source: source.name,
+  is_heart: 0,
+  resource_ratio: "",
+  resource_time: resource.time,
+  musiceffect_id: "",
+  app_mode: 2,
+  bitrate_level: resource.level,
+  vipType: ctx.auth.vipType,
+  fee: resource.fee,
+  file: 4,
+  rightSource: 0,
+  sourceId: source.id,
+  sourcetype: source.type,
+  libra_abt: "",
+  channel: ctx.app.channel,
+  curStartChannel: "",
+});
+
+export const buildPld = (
+  ctx: PlaybackLogContext,
+  resource: PlaybackLogResource,
+  source: PlaybackLogSource,
+  played: number,
+): Record<string, unknown> => ({
+  mode: "circulation",
+  download: 0,
+  alg: "",
+  status: "front",
+  id: String(resource.id),
+  time: played,
+  type: resource.type,
+  ...(resource.type === "dj" && resource.categoryId !== undefined
+    ? { categoryId: resource.categoryId }
+    : {}),
+  is_listentogether: 0,
+  source: source.name,
+  is_heart: 0,
+  realtime: played,
+  resource_ratio: "",
+  resource_time: resource.time,
+  musiceffect_id: "1001",
+  app_mode: 1,
+  lyriceffect: "default",
+  displayMode: "classic",
+  bitrate: resource.bitrate,
+  bitrate_level: resource.level,
+  vipType: ctx.auth.vipType,
+  fee: resource.fee,
+  file: 4,
+  rightSource: 0,
+  sourceId: source.id,
+  sourcetype: source.type,
+  end: "interrupt",
+  libra_abt: "",
+  channel: ctx.app.channel,
+  curStartChannel: "",
+});

--- a/electron/main/apis/netease/modules/scrobble.test.ts
+++ b/electron/main/apis/netease/modules/scrobble.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Query } from "../core/option";
+import type { RequestFn } from "../core/types";
+import scrobble from "./scrobble";
+
+const createRequest = () => {
+  const calls: Array<{ data: Record<string, unknown> }> = [];
+  const request = (async (_uri, data) => {
+    calls.push({ data });
+    return { status: 200, body: { code: 200 }, cookie: [] };
+  }) as RequestFn;
+  return { calls, request };
+};
+
+describe("网易云原版日志听歌打卡", () => {
+  const sourceCases = [
+    ["list", "song", "list"],
+    ["album", "song", "album"],
+    ["artist", "song", "artist"],
+    ["song", "song", "track"],
+    ["radio", "dj", "djradio"],
+  ] as const;
+
+  for (const [sourceType, resourceType, expected] of sourceCases) {
+    it(`将 ${sourceType} 来源的 ${resourceType} 资源映射为 ${expected}`, async () => {
+      const { calls, request } = createRequest();
+      const resourceId = resourceType === "dj" ? "3081133072" : "123";
+
+      await scrobble(
+        {
+          id: resourceId,
+          sourceid: "456",
+          sourceType,
+          resourceType,
+          time: 60,
+          categoryId: resourceType === "dj" ? 7 : undefined,
+          cookie: {},
+        } satisfies Query,
+        request,
+      );
+
+      assert.equal(calls.length, 2);
+      const [startplay] = JSON.parse(String(calls[0]?.data.logs));
+      const [play] = JSON.parse(String(calls[1]?.data.logs));
+      for (const log of [startplay, play]) {
+        assert.deepEqual(
+          {
+            id: log.json.id,
+            type: log.json.type,
+            sourceId: log.json.sourceId,
+            source: log.json.source,
+            sourcetype: log.json.sourcetype,
+            categoryId: log.json.categoryId,
+          },
+          {
+            id: resourceId,
+            type: resourceType,
+            sourceId: "456",
+            source: expected,
+            sourcetype: expected,
+            categoryId: resourceType === "dj" ? 7 : undefined,
+          },
+        );
+      }
+    });
+  }
+
+  it("任一原版日志请求失败时返回失败状态", async () => {
+    let requestCount = 0;
+    const request: RequestFn = async () => {
+      requestCount += 1;
+      const code = requestCount === 1 ? 200 : 500;
+      return { status: code, body: { code }, cookie: [] };
+    };
+
+    const result = await scrobble(
+      { id: "123", sourceid: "123", time: 60, cookie: {} } satisfies Query,
+      request,
+    );
+
+    assert.equal(result.status, 502);
+    assert.equal(result.body.code, 502);
+    assert.equal(result.body.msg, "原版日志上报失败");
+  });
+});

--- a/electron/main/apis/netease/modules/scrobble.ts
+++ b/electron/main/apis/netease/modules/scrobble.ts
@@ -18,17 +18,45 @@ const scrobble: NeteaseModule = async (query, request) => {
     cookie = "os=osx";
   }
   query.cookie = cookie;
+  const resourceId = String(query.id || "");
+  if (!/^\d+$/.test(resourceId) || resourceId === "0") {
+    return { status: 400, body: { code: 400, msg: "缺少有效的资源 ID" }, cookie: [] };
+  }
+  const playTime = Number(query.time);
+  if (Number.isNaN(playTime) || playTime <= 0) {
+    return { status: 400, body: { code: 400, msg: "缺少有效的播放时长" }, cookie: [] };
+  }
+
+  const resourceType = query.resourceType === "dj" ? "dj" : "song";
+  const sourceType = typeof query.sourceType === "string" ? query.sourceType : "song";
+  const sourceName =
+    resourceType === "dj"
+      ? "djradio"
+      : sourceType === "song"
+        ? "track"
+        : sourceType === "radio"
+          ? "djradio"
+          : sourceType;
+  const sourceId = String(query.sourceid || query.sourceId || resourceId);
+  const categoryId = Number(query.categoryId);
+  const sourceFields = {
+    sourceId,
+    source: sourceName,
+    sourcetype: sourceName,
+    ...(resourceType === "dj" && Number.isFinite(categoryId) ? { categoryId } : {}),
+  };
 
   const startplayData = {
     logs: JSON.stringify([
       {
         action: "startplay",
         json: {
-          id: query.id,
-          type: "song",
+          id: resourceId,
+          type: resourceType,
           mainsite: "1",
           mainsiteWeb: "1",
-          content: `id=${query.sourceid}`,
+          content: `id=${sourceId}`,
+          ...sourceFields,
         },
       },
     ]),
@@ -41,15 +69,14 @@ const scrobble: NeteaseModule = async (query, request) => {
         json: {
           download: 0,
           end: "playend",
-          id: query.id,
-          sourceId: query.sourceid,
-          time: query.time,
-          type: "song",
+          id: resourceId,
+          time: playTime,
+          type: resourceType,
           wifi: 0,
-          source: "list",
           mainsite: "1",
           mainsiteWeb: "1",
-          content: `id=${query.sourceid}`,
+          content: `id=${sourceId}`,
+          ...sourceFields,
         },
       },
     ]),
@@ -60,12 +87,15 @@ const scrobble: NeteaseModule = async (query, request) => {
 
   const startplay = await request("/api/feedback/weblog", startplayData, option);
   const play = await request("/api/feedback/weblog", playData, option);
+  const succeeded = [startplay, play].every(
+    ({ body }) => body?.code === 200 || body?.data === "success",
+  );
 
   return {
-    status: 200,
+    status: succeeded ? 200 : 502,
     body: {
-      code: 200,
-      data: "success",
+      code: succeeded ? 200 : 502,
+      ...(succeeded ? { data: "success" } : { msg: "原版日志上报失败" }),
       details: {
         startplay: startplay.body,
         play: play.body,

--- a/electron/main/apis/netease/modules/scrobble_v1.ts
+++ b/electron/main/apis/netease/modules/scrobble_v1.ts
@@ -8,18 +8,22 @@ import type { NeteaseModule } from "../core/types";
 import {
   buildCookieStr,
   buildMetaJson,
-  buildPld,
-  buildPlv,
   buildRecords,
   doUpload,
   extractContext,
-  parseCookie,
 } from "../core/ncbl";
+import {
+  buildPld,
+  buildPlv,
+  parseCookie,
+  toNcblSourceType,
+  type PlaybackLogResource,
+} from "../core/playLog";
 
 const scrobbleV1: NeteaseModule = async (query) => {
-  const songId = Number(query.id);
-  if (!songId || Number.isNaN(songId)) {
-    return { status: 400, body: { code: 400, msg: "缺少有效的 id (歌曲ID)" }, cookie: [] };
+  const resourceId = Number(query.id);
+  if (!resourceId || Number.isNaN(resourceId)) {
+    return { status: 400, body: { code: 400, msg: "缺少有效的资源 ID" }, cookie: [] };
   }
   const playTime = Number(query.time);
   if (Number.isNaN(playTime) || playTime <= 0) {
@@ -28,7 +32,9 @@ const scrobbleV1: NeteaseModule = async (query) => {
 
   const totalTime = Number(query.total) || playTime;
   const sourceId = String(query.sourceid || query.sourceId || "");
-  const sourceName = typeof query.source === "string" ? query.source : "list";
+  const resourceType = query.resourceType === "dj" ? "dj" : "song";
+  const sourceType = typeof query.sourceType === "string" ? query.sourceType : "song";
+  const ncblSourceType = toNcblSourceType(resourceType, sourceType);
   const rawCookie = query.cookie || "";
   const cookieObj = parseCookie(rawCookie);
   cookieObj.os = "pc";
@@ -37,27 +43,31 @@ const scrobbleV1: NeteaseModule = async (query) => {
     return { status: 401, body: { code: 401, msg: "缺少 MUSIC_U 鉴权令牌" }, cookie: [] };
   }
 
-  const song = {
-    id: songId,
+  const resource: PlaybackLogResource = {
+    id: resourceId,
+    type: resourceType,
+    categoryId: Number.isFinite(Number(query.categoryId)) ? Number(query.categoryId) : undefined,
     name: typeof query.name === "string" ? query.name : "",
     artist: typeof query.artist === "string" ? query.artist : "",
     bitrate: Number(query.bitrate) || 320,
     level: typeof query.level === "string" ? query.level : "exhigh",
-    vip: query.vip === "true" || query.vip === true,
+    fee: Number(query.fee) || 0,
     time: totalTime,
   };
   const source = {
-    id: sourceId || String(songId),
-    type: "track",
-    name: sourceName,
+    id: sourceId || String(resourceId),
+    type: ncblSourceType,
+    name: ncblSourceType,
   };
   const metaJson = buildMetaJson(ctx);
   const cookieStr = buildCookieStr(ctx);
   const ts = Math.floor(Date.now() / 1000);
   const played = Math.min(playTime, totalTime);
-  const plvBody = buildRecords([{ time: ts, action: "_plv", data: buildPlv(ctx, song, source) }]);
+  const plvBody = buildRecords([
+    { time: ts, action: "_plv", data: buildPlv(ctx, resource, source) },
+  ]);
   const pldBody = buildRecords([
-    { time: ts, action: "_pld", data: buildPld(ctx, song, source, played) },
+    { time: ts, action: "_pld", data: buildPld(ctx, resource, source, played) },
   ]);
 
   try {

--- a/electron/main/services/neteaseScrobble.ts
+++ b/electron/main/services/neteaseScrobble.ts
@@ -1,19 +1,14 @@
 import type { Track } from "@shared/types/player";
 import type { NeteaseScrobbleMode } from "@shared/types/settings";
+import {
+  neteaseScrobbleThresholdMs,
+  toNeteaseScrobbleTrack,
+  type NeteaseScrobbleTrack,
+} from "@shared/utils/neteaseScrobble";
 import { store } from "@main/store";
 import { callNetease, getNeteaseCookies } from "@main/apis/netease";
 import { neteaseLog } from "@main/utils/logger";
 import { createPlayProgress } from "@main/services/playProgress";
-
-interface NeteaseScrobbleTrack {
-  id: string;
-  sourceId: string;
-  title: string;
-  artist: string;
-  bitrate: number;
-  level: string;
-  durationSec: number;
-}
 
 let current: NeteaseScrobbleTrack | null = null;
 /** 上一次收到的源时间位置 */
@@ -26,23 +21,6 @@ const isLoggedIn = (): boolean => Boolean(getNeteaseCookies().MUSIC_U);
 
 /** 听歌打卡是否启用 */
 const isScrobbleEnabled = (): boolean => Boolean(store.get("system.neteaseScrobbleEnabled"));
-
-/** 提取接口可接受的数字 id */
-const asNumericId = (value: string | undefined): string | null =>
-  value && /^\d+$/.test(value) ? value : null;
-
-/** NCBL 日志使用桌面客户端的音质字段 */
-const toNcblBitrate = (track: Track): number => {
-  const bitRate = track.quality?.bitRate ?? 320;
-  return bitRate > 10000 ? Math.round(bitRate / 1000) : Math.round(bitRate);
-};
-
-/** NCBL 日志使用网易云音质等级 */
-const toNcblLevel = (track: Track): string => {
-  if (track.quality?.codec?.toLowerCase() === "flac") return "lossless";
-  if ((track.quality?.bitRate ?? 0) >= 320000) return "exhigh";
-  return "higher";
-};
 
 /** 当前配置启用的上报接口 */
 const scrobbleApi = (): string => {
@@ -57,23 +35,6 @@ const ensureScrobbleOk = (api: string, res: { body: any }): void => {
   throw new Error(`${api}: ${msg}`);
 };
 
-/** 从 Track 生成打卡元数据 */
-const toScrobbleTrack = (track: Track | null, durationMs: number): NeteaseScrobbleTrack | null => {
-  if (!track || track.source !== "netease") return null;
-  const id = asNumericId(track.id);
-  const sourceId = asNumericId(track.album?.id);
-  if (!id || !sourceId) return null;
-  return {
-    id,
-    sourceId,
-    title: track.title,
-    artist: track.artists.map((artist) => artist.name).join(" / "),
-    bitrate: toNcblBitrate(track),
-    level: toNcblLevel(track),
-    durationSec: Math.round(durationMs / 1000),
-  };
-};
-
 /** 达标提交一次打卡（登录态判定在此，关着开关由 shouldFire 拦截） */
 const submit = (track: NeteaseScrobbleTrack, playedMs: number): void => {
   if (!isLoggedIn()) return;
@@ -83,12 +44,17 @@ const submit = (track: NeteaseScrobbleTrack, playedMs: number): void => {
   callNetease(api, {
     id: track.id,
     sourceid: track.sourceId,
+    source: track.sourceType,
+    sourceType: track.sourceType,
+    resourceType: track.resourceType,
+    categoryId: track.categoryId,
     time: playedSec,
     total: track.durationSec,
     name: track.title,
     artist: track.artist,
     bitrate: track.bitrate,
     level: track.level,
+    fee: track.fee,
   })
     .then((res) => {
       ensureScrobbleOk(api, res);
@@ -102,6 +68,7 @@ const submit = (track: NeteaseScrobbleTrack, playedMs: number): void => {
 const progress = createPlayProgress<NeteaseScrobbleTrack>({
   onThreshold: submit,
   shouldFire: isScrobbleEnabled,
+  thresholdMs: neteaseScrobbleThresholdMs,
 });
 
 /**
@@ -112,7 +79,7 @@ const progress = createPlayProgress<NeteaseScrobbleTrack>({
  */
 export const onTrackLoaded = (track: Track | null, durationMs: number, autoPlay: boolean): void => {
   cycleId++;
-  current = toScrobbleTrack(track, durationMs);
+  current = toNeteaseScrobbleTrack(track, durationMs);
   progress.load(current?.durationSec ?? 0, current, autoPlay);
   lastPositionMs = 0;
 };

--- a/electron/main/services/neteaseScrobbleMeta.test.ts
+++ b/electron/main/services/neteaseScrobbleMeta.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Track } from "../../../shared/types/player";
+import {
+  neteaseScrobbleThresholdMs,
+  toNeteaseScrobbleTrack,
+} from "../../../shared/utils/neteaseScrobble";
+
+const track: Track = {
+  id: "123",
+  source: "netease",
+  title: "测试歌曲",
+  artists: [{ name: "歌手" }],
+  album: { id: "999", name: "不应作为来源的专辑" },
+  duration: 180000,
+  fee: 1,
+};
+
+describe("网易云听歌打卡元数据", () => {
+  it("短音频也会在播放过半后触发打卡", () => {
+    assert.equal(neteaseScrobbleThresholdMs(15), 7500);
+    assert.equal(neteaseScrobbleThresholdMs(30), 15000);
+    assert.equal(neteaseScrobbleThresholdMs(600), 240000);
+    assert.equal(neteaseScrobbleThresholdMs(0), Infinity);
+  });
+
+  it("没有播放上下文时以歌曲自身作为来源", () => {
+    assert.deepEqual(toNeteaseScrobbleTrack(track, 180000), {
+      id: "123",
+      sourceId: "123",
+      sourceType: "song",
+      resourceType: "song",
+      categoryId: undefined,
+      title: "测试歌曲",
+      artist: "歌手",
+      bitrate: 320,
+      level: "higher",
+      fee: 1,
+      durationSec: 180,
+    });
+  });
+
+  const sourceCases = [
+    ["list", "456"],
+    ["album", "999"],
+    ["artist", "789"],
+  ] as const;
+
+  for (const [sourceType, sourceId] of sourceCases) {
+    it(`保留 ${sourceType} 播放来源`, () => {
+      const value = toNeteaseScrobbleTrack(
+        { ...track, playbackSource: { id: sourceId, type: sourceType } },
+        180000,
+      );
+      assert.ok(value);
+      assert.deepEqual(
+        {
+          sourceId: value.sourceId,
+          sourceType: value.sourceType,
+          resourceType: value.resourceType,
+        },
+        { sourceId, sourceType, resourceType: "song" },
+      );
+    });
+  }
+
+  it("播客声音使用节目 ID 和播客来源", () => {
+    const value = toNeteaseScrobbleTrack(
+      {
+        ...track,
+        id: "2725832901",
+        extId: "3081133072",
+        album: { id: "9988", name: "测试播客" },
+        playbackSource: { id: "9988", type: "radio", categoryId: 7 },
+      },
+      180000,
+    );
+    assert.ok(value);
+    assert.deepEqual(
+      {
+        id: value.id,
+        sourceId: value.sourceId,
+        sourceType: value.sourceType,
+        resourceType: value.resourceType,
+        categoryId: value.categoryId,
+      },
+      {
+        id: "3081133072",
+        sourceId: "9988",
+        sourceType: "radio",
+        resourceType: "dj",
+        categoryId: 7,
+      },
+    );
+  });
+
+  it("搜索结果中的声音从专辑字段恢复播客来源", () => {
+    const value = toNeteaseScrobbleTrack(
+      {
+        ...track,
+        id: "2725832901",
+        extId: "3081133072",
+        album: { id: "9988", name: "测试播客" },
+        playbackSource: undefined,
+      },
+      180000,
+    );
+    assert.ok(value);
+    assert.deepEqual(
+      {
+        id: value.id,
+        sourceId: value.sourceId,
+        sourceType: value.sourceType,
+        resourceType: value.resourceType,
+      },
+      {
+        id: "3081133072",
+        sourceId: "9988",
+        sourceType: "radio",
+        resourceType: "dj",
+      },
+    );
+  });
+});

--- a/shared/types/player.ts
+++ b/shared/types/player.ts
@@ -13,6 +13,19 @@ export type ShuffleMode = "off" | "on";
 /** 歌曲来源：本地 / 流媒体 / 在线平台 */
 export type TrackSource = "local" | "streaming" | Platform;
 
+/** 网易云播放来源类型，用于听歌打卡与多端最近播放归类 */
+export type NeteasePlaybackSourceType = "song" | "list" | "album" | "artist" | "radio";
+
+/** 网易云播放来源上下文 */
+export interface NeteasePlaybackSource {
+  /** 来源资源 ID */
+  id: string;
+  /** 来源资源类型 */
+  type: NeteasePlaybackSourceType;
+  /** 播客声音分类 ID */
+  categoryId?: number;
+}
+
 /** 歌手 */
 export interface Artist {
   id?: string;
@@ -72,6 +85,8 @@ export interface Track {
   extId?: string;
   /** 歌曲来源 */
   source: TrackSource;
+  /** 网易云播放来源上下文 */
+  playbackSource?: NeteasePlaybackSource;
   /** 本地路径 */
   path?: string;
   /** CUE 文件路径 */

--- a/shared/utils/neteaseScrobble.ts
+++ b/shared/utils/neteaseScrobble.ts
@@ -1,0 +1,69 @@
+import type { NeteasePlaybackSourceType, Track } from "../types/player";
+
+export interface NeteaseScrobbleTrack {
+  id: string;
+  sourceId: string;
+  sourceType: NeteasePlaybackSourceType;
+  resourceType: "song" | "dj";
+  categoryId?: number;
+  title: string;
+  artist: string;
+  bitrate: number;
+  level: string;
+  fee: number;
+  durationSec: number;
+}
+
+/**
+ * 计算网易云听歌打卡阈值，短音频同样在播放过半后上报
+ * @param durationSec - 音频总时长（秒）
+ * @returns 触发上报所需的累计播放毫秒数
+ */
+export const neteaseScrobbleThresholdMs = (durationSec: number): number =>
+  durationSec > 0 ? Math.min(durationSec / 2, 240) * 1000 : Infinity;
+
+const asNumericId = (value: string | undefined): string | null =>
+  value && /^\d+$/.test(value) ? value : null;
+
+const toBitrate = (track: Track): number => {
+  const bitRate = track.quality?.bitRate ?? 320;
+  return bitRate > 10000 ? Math.round(bitRate / 1000) : Math.round(bitRate);
+};
+
+const toLevel = (track: Track): string => {
+  if (track.quality?.codec?.toLowerCase() === "flac") return "lossless";
+  if ((track.quality?.bitRate ?? 0) >= 320000) return "exhigh";
+  return "higher";
+};
+
+/**
+ * 从播放曲目生成网易云打卡元数据
+ * @param track - 当前播放曲目
+ * @param durationMs - 引擎确认后的时长
+ * @returns 网易云曲目返回打卡元数据，其余来源返回 null
+ */
+export const toNeteaseScrobbleTrack = (
+  track: Track | null,
+  durationMs: number,
+): NeteaseScrobbleTrack | null => {
+  if (!track || track.source !== "netease") return null;
+  const trackId = asNumericId(track.id);
+  if (!trackId) return null;
+  const voiceId = asNumericId(track.extId);
+  const id = voiceId ?? trackId;
+  const contextId = asNumericId(track.playbackSource?.id);
+  const radioId = asNumericId(track.album?.id);
+  return {
+    id,
+    sourceId: contextId ?? (voiceId ? radioId : null) ?? id,
+    sourceType: voiceId ? "radio" : contextId ? (track.playbackSource?.type ?? "song") : "song",
+    resourceType: voiceId ? "dj" : "song",
+    categoryId: voiceId ? track.playbackSource?.categoryId : undefined,
+    title: track.title,
+    artist: track.artists.map((artist) => artist.name).join(" / "),
+    bitrate: toBitrate(track),
+    level: toLevel(track),
+    fee: track.fee ?? 0,
+    durationSec: Math.round(durationMs / 1000),
+  };
+};

--- a/src/components/list/SongList.vue
+++ b/src/components/list/SongList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Artist, Track, TrackSource } from "@shared/types/player";
+import type { Artist, NeteasePlaybackSource, Track, TrackSource } from "@shared/types/player";
 import type { CollectionType } from "@/types/collection";
 import type { SortField } from "@/types/list";
 import { useMediaStore } from "@/stores/media";
@@ -53,6 +53,8 @@ const props = withDefaults(
     collectionType?: CollectionType;
     /** 集合 ID */
     collectionId?: string;
+    /** 网易云播放来源上下文 */
+    playbackSource?: NeteasePlaybackSource;
     /** 是否有权从集合移除曲目 */
     canRemove?: boolean;
     /** 是否还能继续触底加载 */
@@ -70,6 +72,7 @@ const props = withDefaults(
     source: "local",
     collectionType: undefined,
     collectionId: undefined,
+    playbackSource: undefined,
     canRemove: true,
     hasMore: false,
     loadingMore: false,
@@ -509,7 +512,11 @@ defineExpose({
                     : 'bg-surface-panel border-primary/12 hover:border-primary/30 hover:bg-on-surface/8 active:bg-on-surface/12'
               "
               @click="batch.active.value ? batch.toggle(item.id) : undefined"
-              @dblclick="batch.active.value ? undefined : player.playFrom(sortedItems, index)"
+              @dblclick="
+                batch.active.value
+                  ? undefined
+                  : player.playFrom(sortedItems, index, props.playbackSource)
+              "
               @contextmenu="contextTrack = item"
             >
               <!-- 序号 / 多选 -->
@@ -528,7 +535,7 @@ defineExpose({
                     ? batch.toggle(item.id)
                     : playingId === item.id
                       ? player.togglePlay()
-                      : player.playNow(item)
+                      : player.playNow(item, props.playbackSource)
                 "
               >
                 <!-- 多选模式 -->

--- a/src/core/player/index.ts
+++ b/src/core/player/index.ts
@@ -1,4 +1,4 @@
-import type { Track } from "@shared/types/player";
+import type { NeteasePlaybackSource, Track } from "@shared/types/player";
 import type { TagEditRequest, TagWriteOutcome } from "@shared/types/tagEditor";
 import { handleEvent } from "./events";
 import type { RepeatMode, ShuffleMode } from "@/stores/status";
@@ -568,17 +568,32 @@ export const switchDevice = async (deviceName: string | null): Promise<void> => 
  * 设置队列并从指定位置开始播放
  * @param items - 歌曲列表
  * @param startIndex - 起始播放位置，默认 0
+ * @param playbackSource - 网易云播放来源上下文
  */
-export const playFrom = async (items: readonly Track[], startIndex = 0): Promise<void> => {
+export const playFrom = async (
+  items: readonly Track[],
+  startIndex = 0,
+  playbackSource?: NeteasePlaybackSource,
+): Promise<void> => {
   if (items.length === 0) return;
   const status = useStatusStore();
   const media = useMediaStore();
   // 退出特殊模式
   status.heartMode = false;
   status.fmMode = false;
-  const idx = Math.max(0, Math.min(startIndex, items.length - 1));
-  const isSameTrack = media.track?.id === items[idx]?.id;
-  queue.setQueue(items);
+  const tracks = playbackSource
+    ? items.map((track) =>
+        track.source === "netease"
+          ? {
+              ...track,
+              playbackSource: { ...track.playbackSource, ...playbackSource },
+            }
+          : track,
+      )
+    : items;
+  const idx = Math.max(0, Math.min(startIndex, tracks.length - 1));
+  const isSameTrack = media.track?.id === tracks[idx]?.id;
+  queue.setQueue(tracks);
   status.playIndex = idx;
   if (status.shuffleMode === "on") {
     queue.shuffleQueue(status.playIndex);
@@ -918,18 +933,28 @@ export const insertManyToQueue = (
  * 插入歌曲到当前位置之后并立即播放
  * 如果是当前正在播放的歌曲则继续播放，不重新加载
  */
-export const playNow = async (item: Track): Promise<void> => {
+export const playNow = async (
+  item: Track,
+  playbackSource?: NeteasePlaybackSource,
+): Promise<void> => {
   const status = useStatusStore();
   const media = useMediaStore();
+  const target =
+    playbackSource && item.source === "netease"
+      ? {
+          ...item,
+          playbackSource: { ...item.playbackSource, ...playbackSource },
+        }
+      : item;
   // 同一首歌且已成功加载
-  if (media.track?.id === item.id && status.currentSource) {
+  if (media.track?.id === target.id && status.currentSource) {
     if (!status.isPlaying) play();
     return;
   }
   // 退出 FM
   status.fmMode = false;
-  status.playIndex = insertToQueue(item);
-  await loadTrack(item);
+  status.playIndex = insertToQueue(target);
+  await loadTrack(target);
 };
 
 /**

--- a/src/pages/Artist.vue
+++ b/src/pages/Artist.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { TrackSource } from "@shared/types/player";
+import type { NeteasePlaybackSource, TrackSource } from "@shared/types/player";
 import type { ArtistProfile, CoverItem } from "@/types/artist";
 import { useSettingsStore } from "@/stores/settings";
 import { useUserStore } from "@/stores/user";
@@ -120,9 +120,13 @@ const totalDuration = computed(() => {
   return total > 0 ? formatTime(total) : "";
 });
 
+const playbackSource = computed<NeteasePlaybackSource | undefined>(() =>
+  source === "netease" ? { id: decodeURIComponent(id), type: "artist" } : undefined,
+);
+
 const handlePlayAll = () => {
   if (!artist.value?.tracks.length) return;
-  player.playFrom(artist.value.tracks, 0);
+  player.playFrom(artist.value.tracks, 0, playbackSource.value);
 };
 
 /** 收藏歌手仅支持网易云 */
@@ -333,6 +337,7 @@ const albumItems = computed<CoverItem[]>(() => {
               :items="artist.tracks"
               :search-query="searchQuery"
               :source="source"
+              :playback-source="playbackSource"
               :show-size="source === 'local'"
               :has-more="hasMoreSongs"
               :loading-more="loadingMore"

--- a/src/pages/Collection.vue
+++ b/src/pages/Collection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { TrackSource } from "@shared/types/player";
+import type { NeteasePlaybackSource, TrackSource } from "@shared/types/player";
 import type { Collection, CollectionType } from "@/types/collection";
 import type { DropdownMenuItem } from "@/components/ui/SDropdownMenu.vue";
 import { loadCollection as loadCollectionService } from "@/services/collection";
@@ -117,9 +117,18 @@ const updateTimeText = computed(() => {
   return new Date(collection.value.updateTime).toLocaleDateString();
 });
 
+const playbackSource = computed<NeteasePlaybackSource | undefined>(() => {
+  const current = collection.value;
+  if (!current || current.source !== "netease") return undefined;
+  const sourceType =
+    current.type === "playlist" ? "list" : current.type === "radio" ? "radio" : current.type;
+  if (sourceType !== "list" && sourceType !== "album" && sourceType !== "radio") return undefined;
+  return { id: current.id, type: sourceType };
+});
+
 const handlePlayAll = () => {
   if (!collection.value?.tracks.length) return;
-  player.playFrom(collection.value.tracks, 0);
+  player.playFrom(collection.value.tracks, 0, playbackSource.value);
 };
 
 const searchQuery = ref("");
@@ -324,6 +333,7 @@ onBeforeUnmount(() => {
           :source="source"
           :collection-type="type"
           :collection-id="id"
+          :playback-source="playbackSource"
           :can-remove="manage.canManage.value"
           enable-sort
           @scroll="handleListScroll"

--- a/src/pages/Liked.vue
+++ b/src/pages/Liked.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Track } from "@shared/types/player";
+import type { NeteasePlaybackSource, Track } from "@shared/types/player";
 import type { ContentScope } from "@/types/collection";
 import type { DropdownMenuItem } from "@/components/ui/SDropdownMenu.vue";
 import { useLibraryStore } from "@/stores/library";
@@ -53,9 +53,15 @@ const currentTracks = computed<Track[]>(() =>
   tab.value === "local" ? localTracks.value : user.likedPlaylistTracks,
 );
 
+const playbackSource = computed<NeteasePlaybackSource | undefined>(() =>
+  tab.value === "online" && user.likedPlaylistId
+    ? { id: user.likedPlaylistId, type: "list" }
+    : undefined,
+);
+
 const handlePlayAll = (): void => {
   if (currentTracks.value.length === 0) return;
-  player.playFrom(currentTracks.value, 0);
+  player.playFrom(currentTracks.value, 0, playbackSource.value);
 };
 
 // 直进 /liked（没先访问 Library 页）时本地库未初始化，需要手动触发
@@ -196,6 +202,7 @@ const handleMoreMenu = (key: string): void => {
           :search-query="searchQuery"
           source="netease"
           :collection-id="user.likedPlaylistId ?? undefined"
+          :playback-source="playbackSource"
           collection-type="playlist"
           enable-sort
         />


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

修复「设置 → 听歌打卡」中原版日志接口和 NCBL 加密接口的错误上报参数：

- 从歌单、专辑、歌手及喜欢列表开始播放时保留真实播放来源，避免把专辑 ID 误当作来源 ID。
- 原版日志的 `startplay` 与 `play` 统一上报正确的资源 ID、`sourceId`、`source`、`sourcetype`、资源类型及播客分类。
- NCBL 的 PLV/PLD 使用真实来源类型、来源 ID、`fee` 和播客分类，不再写死 `track/list` 或附带不匹配当前上下文的引用参数。
- 支持播客声音以节目 ID、`dj` 资源类型和 `djradio` 来源上报，为后续播客功能接入保留完整参数模型。
- 修复短音频不打卡：网易云有效音频统一在累计播放过半时提交，最长仍为 240 秒；15 秒歌曲或声音约在 7.5 秒触发。Last.fm 原有的短音频规则不受影响。
- 原版日志任一请求失败时返回失败状态，避免把部分失败误判为成功。

## 关联 Issue

无。

## 测试情况

- Windows：`pnpm dev` 分支预览启动成功，主进程、渲染进程及原生音频模块均正常加载。
- `pnpm format`：通过，无格式差异。
- `pnpm lint`：通过。
- `pnpm typecheck`：通过。
- `pnpm test:node`：33 项测试全部通过。
- 新增回归测试覆盖歌曲、歌单、专辑、歌手、播客声音、原版日志、NCBL 参数、失败回包和短音频阈值。
- 使用模拟时钟分别验证 `song` 与 `dj`：15 秒音频在 7.5 秒触发一次，`ended` 可结算补交且不会重复提交。

## 截图 / 录屏

不涉及 UI 改动。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交