### PR TITLE
perf: 优化打包大小

### DIFF
--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -5,7 +5,7 @@ const config: Configuration = {
   productName: "SPlayer-Next",
   copyright: "Copyright © imsyy 2025",
   directories: { buildResources: "public" },
-  // afterPack: "./scripts/after-pack.ts",
+  afterPack: "./scripts/after-pack.ts",
   compression: "maximum",
   files: [
     "public/**",
@@ -23,9 +23,9 @@ const config: Configuration = {
     "!{components.d.ts,auto-imports.d.ts}",
     "!{.env,.env.*,.npmrc,pnpm-lock.yaml}",
     "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}",
-    "!**/*.{d.ts,map,md}",
-    "!**/{CHANGELOG,LICENSE,license,README,readme}*",
-    "!**/node_modules/better-sqlite3/deps/**",
+    "!**/*.{d.ts,ts,map,md}",
+    "!**/{CHANGELOG,README,readme}*",
+    "!**/node_modules/better-sqlite3/{deps,src}/**",
   ],
   // 保留的语言
   electronLanguages: ["zh-CN", "en-US"],

--- a/scripts/after-pack.ts
+++ b/scripts/after-pack.ts
@@ -1,26 +1,91 @@
-import type { AfterPackContext } from "electron-builder";
-import { readdir, unlink } from "fs/promises";
+import { type AfterPackContext, Arch } from "electron-builder";
 import { join } from "path";
+import { rm } from "node:fs/promises";
 
-/** 保留的 locale */
-const keepLocales = new Set(["en-US.pak", "zh-CN.pak"]);
+let hasWarnedCleanupOnce = false;
+const printCleanupWarningOnce = () => {
+  if (!hasWarnedCleanupOnce) {
+    hasWarnedCleanupOnce = true;
+    console.warn(
+      `[AfterPack] 部分文件清理失败。这不会影响 App 构建和运行，但可能导致包体积略大于预期。`,
+    );
+  }
+};
 
-/** 打包后清理多余的 Chromium locale 文件 */
+const tryRm = async (path: string, options?: object): Promise<void> => {
+  try {
+    await rm(path, options);
+  } catch (error: any) {
+    printCleanupWarningOnce();
+    console.warn(`[AfterPack] 清理失败 "${path}": ${error.message}`);
+  }
+};
+
 const afterPack = async (context: AfterPackContext): Promise<void> => {
-  const localeDir = join(
+  const resourceDir = join(
     context.appOutDir,
     context.packager.platform.name === "mac"
-      ? `${context.packager.appInfo.productFilename}.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources`
-      : "locales",
+      ? `${context.packager.appInfo.productFilename}.app/Contents/Resources`
+      : "resources",
   );
-  try {
-    const files = await readdir(localeDir);
-    await Promise.all(
-      files
-        .filter((f) => f.endsWith(".pak") && !keepLocales.has(f))
-        .map((f) => unlink(join(localeDir, f))),
-    );
-  } catch {}
+
+  await Promise.all([
+    trimBetterSqlite3(resourceDir, context),
+    trimFontListLibs(resourceDir, context),
+  ]);
+};
+
+const trimBetterSqlite3 = async (resourceDir: string, context: AfterPackContext) => {
+  const dir = join(resourceDir, "app.asar.unpacked/node_modules/better-sqlite3/");
+  const allPlatform = ["win32", "darwin", "linux", "linuxmusl"];
+  const allArch = ["x64", "arm64"];
+  const keepPlatform = new Set<string>([context.electronPlatformName]); // 暂时不考虑 linuxmusl
+  const keepArch = new Set<string>();
+
+  switch (context.arch) {
+    case Arch.x64:
+      keepArch.add("x64");
+      break;
+    case Arch.arm64:
+      keepArch.add("arm64");
+      break;
+    case Arch.universal:
+      keepArch.add("x64");
+      keepArch.add("arm64");
+      break;
+    default:
+      printCleanupWarningOnce();
+      console.error("[AfterPack] 未知架构: " + context.arch);
+      return;
+  }
+
+  const deletePromises: Promise<void>[] = [];
+  for (const platform of allPlatform) {
+    for (const arch of allArch) {
+      if (keepPlatform.has(platform) && keepArch.has(arch)) continue;
+      const fileName = `${platform}-${arch}`;
+      deletePromises.push(
+        tryRm(join(dir, "prebuilds", `${fileName}.node`), { force: true }),
+        tryRm(join(dir, "lib", `${fileName}.js`), { force: true }),
+      );
+    }
+  }
+
+  await Promise.all(deletePromises);
+};
+
+const trimFontListLibs = async (resourceDir: string, context: AfterPackContext) => {
+  const dir = join(resourceDir, "app.asar.unpacked/node_modules/font-list/libs/");
+  const allPlatform = ["win32", "darwin", "linux"];
+  const keepPlatform = new Set<string>([context.electronPlatformName]);
+
+  const deletePromises: Promise<void>[] = [];
+  for (const platform of allPlatform) {
+    if (keepPlatform.has(platform)) continue;
+    deletePromises.push(tryRm(join(dir, platform), { recursive: true, force: true }));
+  }
+
+  await Promise.all(deletePromises);
 };
 
 export default afterPack;


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [ ] 缺陷修复（fix）
- [x] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

 - 优化了 `better-sqlite3` 和 `font-list` 的体积（根据平台删除不会用到的东西）
 - 排除了部分依赖中的 TypeScript `.ts` 源代码文件

## 测试情况

`resources` 从 55.4 MiB 缩减至 38.7 MiB，且不影响正常功能

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
