### PR TITLE
build: 添加 Nix flake 支持

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,170 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default-linux";
+  };
+
+  outputs =
+    { nixpkgs, systems, ... }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = eachSystem (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          inherit (pkgs) lib;
+
+          electron = pkgs.electron_43;
+
+          packageJson = builtins.fromJSON (builtins.readFile ./package.json);
+
+          splayer-next = pkgs.stdenv.mkDerivation (finalAttrs: {
+            inherit (packageJson) version;
+
+            pname = "splayer-next";
+            src = ./.;
+
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit (finalAttrs) pname version src;
+              hash = "sha256-Ll+nfLfKQapsBc/vGabmd4xuSvYg/XnyLBg9w9hYlhY=";
+              fetcherVersion = 4;
+            };
+
+            cargoDeps = pkgs.rustPlatform.importCargoLock {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = [
+              pkgs.pnpmConfigHook
+              pkgs.pnpm
+              pkgs.nodejs
+              pkgs.rustPlatform.cargoSetupHook
+              pkgs.rustPlatform.bindgenHook
+              pkgs.cargo
+              pkgs.rustc
+              pkgs.python3
+              pkgs.makeWrapper
+              pkgs.copyDesktopItems
+              pkgs.pkg-config
+            ];
+
+            buildInputs = [
+              pkgs.pipewire
+              pkgs.libpulseaudio
+              pkgs.openssl
+              pkgs.ffmpeg-headless
+              pkgs.alsa-lib
+            ];
+
+            strictDeps = true;
+            __structuredAttrs = true;
+
+            env = {
+              ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+              FFMPEG_MODE = "system";
+            };
+
+            postPatch = ''
+              # Workaround for https://github.com/electron/electron/issues/31121
+              substituteInPlace electron/main/utils/nativeLoader.ts \
+                --replace-fail 'process.resourcesPath' "'$out/share/splayer-next/resources'"
+
+              substituteInPlace electron/main/services/recognition/fingerprint.ts \
+                --replace-fail 'process.resourcesPath' "'$out/share/splayer-next/resources'"
+
+              sed -i '/^[[:space:]]*\.atleast_version/d' \
+                "$cargoDepsCopy"/{.,*}/ffmpeg_audio_sys-*/build.rs
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+
+              # After the pnpm configure, we need to build the binaries of all instances
+              # of better-sqlite3. It has a native part that it wants to build using a
+              # script which is disallowed.
+              # What's more, we need to use headers from electron to avoid ABI mismatches.
+              for f in $(find . -path '*/node_modules/better-sqlite3' -type d); do
+                (cd "$f" && (
+                  npm run build-release --offline -- --nodedir="${electron.headers}"
+                  rm -rf prebuilds
+                  rm -rf build/Release/{.deps,obj,obj.target,test_extension.node}
+                  find build -type f -exec \
+                    ${lib.getExe pkgs.removeReferencesTo} \
+                    -t "${electron.headers}" {} \;
+                ))
+              done
+
+              pnpm build
+
+              npm exec electron-builder -- \
+                --dir \
+                --config electron-builder.config.ts \
+                -c.electronDist=${electron.dist} \
+                -c.electronVersion=${electron.version}
+
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p "$out/share/splayer-next"
+              cp -Pr --no-preserve=ownership dist/*-unpacked/{locales,resources{,.pak}} $out/share/splayer-next
+
+              _icon_sizes=(16x16 32x32 96x96 192x192 256x256 512x512)
+              for _icons in "''${_icon_sizes[@]}";do
+                install -D public/icons/favicon-$_icons.png $out/share/icons/hicolor/$_icons/apps/splayer-next.png
+              done
+
+              makeWrapper '${lib.getExe electron}' "$out/bin/splayer-next" \
+                --add-flags $out/share/splayer-next/resources/app.asar \
+                --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+                --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+                --set-default ELECTRON_IS_DEV 0 \
+                --prefix LD_PRELOAD : "${pkgs.ffmpeg-headless.lib}/lib/libavformat.so" \
+                --prefix LD_PRELOAD : "${pkgs.ffmpeg-headless.lib}/lib/libavcodec.so" \
+                --prefix LD_PRELOAD : "${pkgs.ffmpeg-headless.lib}/lib/libavutil.so" \
+                --prefix LD_PRELOAD : "${pkgs.ffmpeg-headless.lib}/lib/libswresample.so" \
+                --inherit-argv0
+
+              runHook postInstall
+            '';
+
+            desktopItems = [
+              (pkgs.makeDesktopItem {
+                name = "top.imsyy.splayer_next";
+                desktopName = "SPlayer-Next";
+                exec = "splayer-next %U";
+                terminal = false;
+                type = "Application";
+                icon = "splayer-next";
+                startupWMClass = "top.imsyy.splayer_next";
+                comment = "Cross-platform desktop music player with rich lyric support and wide audio format compatibility";
+                categories = [
+                  "AudioVideo"
+                  "Audio"
+                  "Music"
+                ];
+                mimeTypes = [ "x-scheme-handler/orpheus" ];
+                extraConfig.X-KDE-Protocols = "orpheus";
+              })
+            ];
+
+            meta = {
+              description = "Cross-platform desktop music player with rich lyric support";
+              homepage = "https://splayer-next.imsyy.top";
+              license = lib.licenses.agpl3Only;
+              mainProgram = "splayer-next";
+              platforms = lib.platforms.linux;
+            };
+          });
+        in
+        {
+          default = splayer-next;
+          inherit splayer-next;
+        }
+      );
+    };
+}


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [x] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

<!-- 这个 PR 做了什么、为什么这么做（动机 + 主要变更），尽量描述清楚 -->
这个 flake 基于 nixpkgs 中现有的 SPlayer 打包方案。

这个 PR 添加了一个用于打包该应用的 Nix flake，使 Nix 用户能够轻松地在自己的 flake 中引用并构建该应用。

~~此外，这个 PR 还更新了 `pnpm-lock.yaml`，因为 `fetchPnpmDeps` 要求使用最新的 lockfile，否则 flake 将无法构建。~~ 这是我的误解，lockfile 已恢复到之前的版本。

`fetchPnpmDeps` 还要求提供依赖关系图的哈希值，这意味着每当依赖关系图发生变化时，都需要相应更新 flake。因此，我愿意在依赖关系发生变化导致 flake 失效时负责更新它。

## 测试情况

<!-- 如何验证这些改动？手动复现步骤、覆盖到的平台（Windows / macOS / Linux）等 -->
这个 flake 已在 NixOS 26.11.20260801.148bab9（Zokor）x86-64 Linux 上进行了测试。构建成功生成了应用程序，包括可执行文件、桌面文件、图标以及其他所需资源。生成的可执行文件能够正常启动 SPlayer-Next，在测试期间未遇到任何崩溃。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交

## 免责声明

我不懂中文，因此需要使用 LLM 帮助我翻译 PR 模板。我先用英文回答了模板中的问题，然后使用 LLM 将其翻译成中文。由于我无法核实翻译的准确性，因此我同时附上了英文原文和中文翻译，以便他人可以独立核实我所提供的信息。

## Disclaimer

I do not understand Chinese, so I had to use an LLM to translate the PR template. I wrote my responses to the questions in English and then used an LLM to translate them into Chinese. Since I am unable to verify the accuracy of the translation, I am including the English text alongside the Chinese translation so that the information I provided can be independently verified.

<!--
Thank you for contributing! Before submitting, please confirm:
1. Keep each PR focused on one main feature or fix where possible, so it is easier to review and revert; split unrelated changes into separate PRs.
2. Submit the PR to the `dev` branch.
3. If the changes contain AI-generated code, make sure you fully test and review it yourself and take responsibility for its correctness. Do not submit unverified code directly.
-->

## Change Type

- [ ] New feature (feat)
- [ ] Bug fix (fix)
- [ ] Refactor / optimization (no externally visible behavior changes)
- [ ] Documentation (docs)
- [x] Other (please specify in "Description")

## Does this include breaking changes?

- [ ] Yes (describe in detail in "Description")
- [x] No

## Description

<!-- What does this PR do, and why? (Motivation + main changes) Please describe it clearly. -->
This flake is based on the existing SPlayer packaging recipe in nixpkgs.

This PR adds a Nix flake that packages the application, allowing Nix users to easily include and build it in their own flakes.

~~This PR also updates `pnpm-lock.yaml`, as `fetchPnpmDeps` requires an up-to-date lockfile and the flake fails to build without it.~~ This was a misconception on my part, lockfile was restored to its previous version.

`fetchPnpmDeps` also requires a hash of the dependency graph, meaning the flake will need to be updated whenever the dependency graph changes. Therefore, I volunteer to update the flake whenever this happens.

## Testing

The flake was tested on NixOS 26.11.20260801.148bab9 (Zokor) on x86-64 Linux. It successfully builds the application, including the executable, desktop entry, icons, and other required resources. The resulting executable launches SPlayer-Next successfully, and I have not encountered any crashes during my testing.

## Checklist

- [x] This PR contains only **one main feature / fix** and does not include unrelated changes
- [x] I have **fully tested** the changes locally; any **AI-generated code has also been tested and reviewed** by me and no unverified code has been submitted
- [x] I have run `pnpm format` and confirmed that `pnpm typecheck` and `pnpm lint` pass
- [x] If the changes involve native modules, I have verified them with `pnpm build:native`; I have not manually written `native/*/index.d.ts`
- [x] I have submitted this PR to the `dev` branch