### PR TITLE
fix: 修复“灵动悬浮”模式遮挡统计页的部分元素的问题

### DIFF
--- a/src/pages/Stats.vue
+++ b/src/pages/Stats.vue
@@ -7,6 +7,9 @@ import type {
   TopArtist,
   TopTrack,
 } from "@shared/types/stats";
+import { useFloatingPlayerBar } from "@/composables/useFloatingPlayerBar";
+
+const { isFloatingBar } = useFloatingPlayerBar();
 
 const libraryStats = ref<LibraryStats | null>(null);
 const daily = ref<DailyPlayStats[]>([]);
@@ -40,7 +43,10 @@ onMounted(async () => {
 
 <template>
   <div class="h-full overflow-y-auto [scrollbar-gutter:stable]">
-    <div class="mx-auto flex max-w-[1400px] flex-col gap-5 px-5 pt-2 pb-10">
+    <div
+      class="mx-auto flex max-w-[1400px] flex-col gap-5 px-5 pt-2"
+      :class="isFloatingBar ? 'pb-28' : 'pb-10'"
+    >
       <!-- 曲库概览 -->
       <StatsOverview :stats="libraryStats" />
       <!-- 聆听足迹、播放时段与音质构成 -->


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

<!-- 这个 PR 做了什么、为什么这么做（动机 + 主要变更），尽量描述清楚 -->
修复“灵动悬浮”模式遮挡统计页的部分元素的问题

## 关联 Issue

<!-- 如有关联，填 #编号；写 "Closes #编号" 可在合并时自动关闭对应 Issue -->
fix #152 

## 测试情况

<!-- 如何验证这些改动？手动复现步骤、覆盖到的平台（Windows / macOS / Linux）等 -->
见截图

## 截图 / 录屏

<!-- 涉及 UI 改动请附上；无则可删除本节 -->
<img width="2520" height="1607" alt="image" src="https://github.com/user-attachments/assets/618085fa-bc51-4011-89d0-5035c07653fb" />


## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
