### PR TITLE
fix: 修复窗口缩小时界面溢出与原生滚动条 fixes #149

### DIFF
--- a/electron/main/window/create.ts
+++ b/electron/main/window/create.ts
@@ -8,8 +8,8 @@ import icon from "../../../public/icons/favicon.png?asset";
 const getDefaultOptions = (): BrowserWindowConstructorOptions => ({
   width: 1280,
   height: 800,
-  minWidth: 800,
-  minHeight: 600,
+  minWidth: 1280,
+  minHeight: 800,
   autoHideMenuBar: true,
   show: false,
   backgroundColor: nativeTheme.shouldUseDarkColors ? "#101014" : "#f6f6f6",

--- a/src/components/layout/NavHeader.vue
+++ b/src/components/layout/NavHeader.vue
@@ -57,11 +57,11 @@ const onMenuSelect = (key: string): void => {
 </script>
 
 <template>
-  <div class="flex items-center flex-1 h-full app-drag-region">
+  <div class="flex items-center justify-between flex-1 h-full min-w-0 app-drag-region">
     <!-- 左侧 -->
-    <div class="flex items-center gap-3 shrink-0">
+    <div class="flex items-center gap-2 sm:gap-3 min-w-0 shrink-0">
       <SButton
-        class="app-no-drag"
+        class="app-no-drag shrink-0"
         variant="tertiary"
         circle
         :size="40"
@@ -71,7 +71,7 @@ const onMenuSelect = (key: string): void => {
         <template #icon><IconLucideChevronLeft /></template>
       </SButton>
       <SButton
-        class="app-no-drag"
+        class="app-no-drag shrink-0"
         variant="tertiary"
         circle
         :size="40"
@@ -80,9 +80,10 @@ const onMenuSelect = (key: string): void => {
       >
         <template #icon><IconLucideChevronRight /></template>
       </SButton>
+      <NavSearch />
       <SButton
         v-if="update.hasUpdate"
-        class="app-no-drag"
+        class="app-no-drag shrink-0"
         variant="tertiary"
         circle
         :size="40"
@@ -93,16 +94,14 @@ const onMenuSelect = (key: string): void => {
         <template #icon><IconLucideCircleArrowUp /></template>
       </SButton>
     </div>
-    <!-- 中间：搜索框，窄窗口下可收缩 -->
-    <div class="flex-1 min-w-0 mx-3">
-      <NavSearch />
-    </div>
+    <!-- 中间 -->
+    <div class="flex-1 h-full min-w-4" />
     <!-- 右侧 -->
-    <div class="flex items-center gap-3 shrink-0">
+    <div class="flex items-center gap-2 sm:gap-3 shrink-0">
       <NavUser />
       <SDropdownMenu :items="menuItems" @select="onMenuSelect">
         <template #trigger>
-          <SButton class="app-no-drag" variant="tertiary" circle :size="40">
+          <SButton class="app-no-drag shrink-0" variant="tertiary" circle :size="40">
             <template #icon><IconLucideSettings /></template>
           </SButton>
         </template>

--- a/src/components/layout/NavHeader.vue
+++ b/src/components/layout/NavHeader.vue
@@ -80,7 +80,6 @@ const onMenuSelect = (key: string): void => {
       >
         <template #icon><IconLucideChevronRight /></template>
       </SButton>
-      <NavSearch />
       <SButton
         v-if="update.hasUpdate"
         class="app-no-drag"
@@ -94,8 +93,10 @@ const onMenuSelect = (key: string): void => {
         <template #icon><IconLucideCircleArrowUp /></template>
       </SButton>
     </div>
-    <!-- 中间 -->
-    <div class="flex-1 h-full" />
+    <!-- 中间：搜索框，窄窗口下可收缩 -->
+    <div class="flex-1 min-w-0 mx-3">
+      <NavSearch />
+    </div>
     <!-- 右侧 -->
     <div class="flex items-center gap-3 shrink-0">
       <NavUser />

--- a/src/components/layout/NavSearch.vue
+++ b/src/components/layout/NavSearch.vue
@@ -276,11 +276,11 @@ onMounted(() => {
 
 <template>
   <!-- 搜索框触发器与听歌识曲 -->
-  <div class="flex items-center gap-2 min-w-0 w-full max-w-72">
+  <div class="flex items-center gap-2 shrink-0">
     <div
       role="button"
       :aria-label="t('nav.searchPlaceholder')"
-      class="app-no-drag flex-1 w-full max-w-60 min-w-0 h-10 px-4 cursor-pointer flex items-center gap-2 rounded-full border border-solid bg-on-surface/3 border-on-surface/15 hover:bg-on-surface/10 hover:border-on-surface/25 transition-colors duration-250 select-none"
+      class="app-no-drag w-60 h-10 px-4 cursor-pointer flex items-center gap-2 rounded-full border border-solid bg-on-surface/3 border-on-surface/15 hover:bg-on-surface/10 hover:border-on-surface/25 transition-colors duration-250 select-none"
       @click="dialogOpen = true"
       @contextmenu.prevent="dialogOpen = true"
       @mousedown.prevent

--- a/src/components/layout/NavSearch.vue
+++ b/src/components/layout/NavSearch.vue
@@ -275,11 +275,12 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex items-center gap-2 shrink-0">
+  <!-- 搜索框触发器与听歌识曲 -->
+  <div class="flex items-center gap-2 min-w-0 w-full max-w-72">
     <div
       role="button"
       :aria-label="t('nav.searchPlaceholder')"
-      class="app-no-drag w-60 h-10 px-4 cursor-pointer flex items-center gap-2 rounded-full border border-solid bg-on-surface/3 border-on-surface/15 hover:bg-on-surface/10 hover:border-on-surface/25 transition-colors duration-250 select-none"
+      class="app-no-drag flex-1 w-full max-w-60 min-w-0 h-10 px-4 cursor-pointer flex items-center gap-2 rounded-full border border-solid bg-on-surface/3 border-on-surface/15 hover:bg-on-surface/10 hover:border-on-surface/25 transition-colors duration-250 select-none"
       @click="dialogOpen = true"
       @contextmenu.prevent="dialogOpen = true"
       @mousedown.prevent

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -114,7 +114,7 @@ const playerBarInnerClass = computed(() => {
 <template>
   <!-- 主界面 -->
   <div
-    class="h-screen flex bg-app text-on-surface transition-[transform,opacity] duration-500 ease-[cubic-bezier(0.7,0,0.3,1)] origin-center"
+    class="h-screen flex overflow-hidden bg-app text-on-surface transition-[transform,opacity] duration-500 ease-[cubic-bezier(0.7,0,0.3,1)] origin-center"
     :class="isPlayerExpanded ? 'scale-95 opacity-0 pointer-events-none' : ''"
   >
     <!-- 侧边栏 -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,6 +104,7 @@ html[data-appearance-style="image"] [role="alertdialog"] .bg-field {
 /* 滚动条 */
 ::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

**修复 #149：窗口缩小到较窄宽度时，顶栏文字与控件溢出、重叠，并出现浏览器原生的粗横向滚动条。**

**动机**：窗口最小宽度为 800px，此时侧边栏占 240px，顶栏可用宽度仅剩约 560px。顶栏左侧按钮组、固定宽度搜索框（240px）与右侧按钮组（登录状态下含头像昵称与窗口控制按钮，可超过 300px）均为 `shrink-0` 不可收缩，固有宽度之和超过可用宽度，必然溢出。同时主界面根容器（`h-screen flex`）未设置 `overflow-hidden`，溢出一路传播到 document 层触发整页原生滚动条；滚动条样式只设置了 `width` 未设置 `height`，横向滚动条退化为未样式的粗条。

**主要变更**：
- `NavHeader.vue`：将固定宽度的搜索框从 `shrink-0` 左侧按钮组移出，放入独立的 `flex-1 min-w-0` 可收缩插槽。窄窗口下左右按钮组保持完整，搜索框优先压缩。
- `NavSearch.vue`：搜索框触发样式由 `w-60`（固定 240px）改为 `w-full max-w-60 min-w-0`——空间充足时仍保持最多 240px，空间不足时自动收缩，不再溢出。
- `MainLayout.vue`：主界面根容器增加 `overflow-hidden`，阻止内容溢出传播到 document 层，消除原生整页滚动条；内容滚动仍由内部 `main` 的 `overflow-y-auto` 负责。
- `global.css`：`::-webkit-scrollbar` 补充 `height: 6px`，使横向滚动条与纵向统一为 6px 细样式（兜底）。

## 关联 Issue

#149

## 测试情况

- `pnpm typecheck` 通过
- 手动复现：默认布局下将窗口宽度逐渐拖窄至最小值（800px），顶栏不再溢出、无原生横向滚动条；搜索框正常收缩，按钮组完整可用
- 
## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交