### PR TITLE
feat: 重构 LRC 解析逻辑以支持元数据格式的背景行和尾随背景行处理

### DIFF
--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -65,10 +65,9 @@ describe("lyric parse", () => {
   it("将空时间标签保留为结束上一行的空白时间节点", () => {
     const lines = parseLyric({ content: "[00:00.00]A\n[00:01.00]\n[00:02.00]B" }, "lrc");
 
-    expect(lines).toHaveLength(3);
+    expect(lines).toHaveLength(2);
     expect(lines[0].endTime).toBe(1_000);
-    expect(lines[1]).toMatchObject({ startTime: 1_000, endTime: 2_000, words: [] });
-    expect(lines[2].startTime).toBe(2_000);
+    expect(lines[1].startTime).toBe(2_000);
   });
 
   it("使用 ESLRC 末尾时间标签结束最后一个字", () => {

--- a/src/utils/lyric/parseLRC.ts
+++ b/src/utils/lyric/parseLRC.ts
@@ -1,25 +1,12 @@
 import type { LyricLine, LyricWord } from "@shared/types/lyrics";
 import { BRACKET_TIME_RE, ANGLE_TIME_RE, parseTime, MAX_TIME } from "./timestamp";
-import { detectBackgroundLine } from "./bg";
+import { detectBackgroundLine, splitTrailingBackground } from "./bg";
 
 /** 匹配元数据标签（如 [ti:xxx]、[ar:xxx]） */
-const META_TAG_RE = /^\[[a-zA-Z]+:/;
+const META_TAG_RE = /^\[([a-zA-Z]+):(.*?)]$/;
 
 /** 检测尖括号逐字标签 */
 const HAS_ANGLE_TAGS = /<\d+:\d+/;
-
-/**
- * 判断一行原始文本是否应跳过（非歌词内容）
- * @param line trim 后的行文本
- */
-const shouldSkipLine = (line: string): boolean => {
-  if (!line) return true;
-  // 元数据标签：[ti:xxx]、[ar:xxx] 等
-  if (META_TAG_RE.test(line)) return true;
-  // JSON 行（平台的扩展元数据）
-  if (line.startsWith("{")) return true;
-  return false;
-};
 
 /**
  * 提取行首连续的方括号时间戳
@@ -114,6 +101,115 @@ const parseLrcWords = (line: string): LyricWord[] | null => {
   return words;
 };
 
+const parseLrcPayload = (line: string, detectBackground: boolean = true): LyricLine[] => {
+  // 提取行首连续时间戳
+  const { times, textStart } = extractHeaderTimes(line);
+  if (times.length === 0) return [];
+  // 提取行内容
+  const content = line.slice(textStart);
+  if (!content.trim()) {
+    const lines: LyricLine[] = [];
+    for (const t of times) {
+      lines.push({
+        words: [],
+        translatedLyric: "",
+        romanLyric: "",
+        startTime: t,
+        endTime: 0,
+        isBG: false,
+        isDuet: false,
+      });
+    }
+    return lines;
+  }
+  // 尝试 ESLRC 逐字
+  const eslrcWords = parseEslrcWords(content);
+  if (eslrcWords) {
+    const lines: LyricLine[] = [];
+    for (const _ of times) {
+      // 多时间戳时克隆单词数组
+      const words = times.length > 1 ? eslrcWords.map((w) => ({ ...w })) : eslrcWords;
+      lines.push({
+        words,
+        translatedLyric: "",
+        romanLyric: "",
+        startTime: words[0].startTime,
+        endTime: words[words.length - 1].endTime,
+        isBG: detectBackgroundLine(words, detectBackground),
+        isDuet: false,
+      });
+    }
+    return lines;
+  }
+  // 尝试 LRC 逐字
+  const lrcWords = parseLrcWords(line);
+  if (lrcWords) {
+    const lines: LyricLine[] = [];
+    lines.push({
+      words: lrcWords,
+      translatedLyric: "",
+      romanLyric: "",
+      startTime: lrcWords[0].startTime,
+      endTime: lrcWords[lrcWords.length - 1].endTime,
+      isBG: detectBackgroundLine(lrcWords, detectBackground),
+      isDuet: false,
+    });
+    return lines;
+  }
+  // 回退标准整行模式
+  const lineWords = [{ startTime: 0, endTime: 0, word: content.trim() }];
+  const isBG = detectBackgroundLine(lineWords, detectBackground);
+  const lines: LyricLine[] = [];
+  for (const t of times) {
+    lines.push({
+      words: [{ startTime: t, endTime: 0, word: lineWords[0].word }],
+      translatedLyric: "",
+      romanLyric: "",
+      startTime: t,
+      endTime: 0,
+      isBG,
+      isDuet: false,
+    });
+  }
+  return lines;
+};
+
+const parseLrcLine = (line: string, detectBackground: boolean = true): LyricLine[] => {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  const match = META_TAG_RE.exec(trimmed);
+  if (match) {
+    const key = match[1];
+    const value = match[2];
+
+    if (key === "bg") {
+      const lines = parseLrcPayload(value, detectBackground);
+      if (lines.length === 1) {
+        lines[0].isBG = true;
+        return lines;
+      }
+    }
+
+    return [];
+  }
+
+  // JSON 行（平台的扩展元数据）
+  if (line.startsWith("{")) return [];
+
+  const lines = parseLrcPayload(trimmed, detectBackground);
+  const result: LyricLine[] = [];
+  for (const line of lines) {
+    result.push(line);
+    // 行内尾随和声「主歌词（和声）」拆成紧随的背景行
+    if (!line.isBG) {
+      const bg = splitTrailingBackground(line, detectBackground);
+      if (bg) result.push(bg);
+    }
+  }
+  return result;
+};
+
 /**
  * 解析 LRC 歌词文本
  * @param text LRC 文本内容
@@ -121,74 +217,8 @@ const parseLrcWords = (line: string): LyricWord[] | null => {
  */
 export const parseLRC = (text: string, detectBackground = true): LyricLine[] => {
   const lines: LyricLine[] = [];
-  for (const raw of text.split("\n")) {
-    const trimmed = raw.trim();
-    if (shouldSkipLine(trimmed)) continue;
-    // 提取行首连续时间戳
-    const { times, textStart } = extractHeaderTimes(trimmed);
-    if (times.length === 0) continue;
-    // 提取行内容
-    const content = trimmed.slice(textStart);
-    if (!content.trim()) {
-      for (const t of times) {
-        lines.push({
-          words: [],
-          translatedLyric: "",
-          romanLyric: "",
-          startTime: t,
-          endTime: 0,
-          isBG: false,
-          isDuet: false,
-        });
-      }
-      continue;
-    }
-    // 尝试 ESLRC 逐字
-    const eslrcWords = parseEslrcWords(content);
-    if (eslrcWords) {
-      for (const _ of times) {
-        // 多时间戳时克隆单词数组
-        const words = times.length > 1 ? eslrcWords.map((w) => ({ ...w })) : eslrcWords;
-        lines.push({
-          words,
-          translatedLyric: "",
-          romanLyric: "",
-          startTime: words[0].startTime,
-          endTime: words[words.length - 1].endTime,
-          isBG: detectBackgroundLine(words, detectBackground),
-          isDuet: false,
-        });
-      }
-      continue;
-    }
-    // 尝试 LRC 逐字
-    const lrcWords = parseLrcWords(trimmed);
-    if (lrcWords) {
-      lines.push({
-        words: lrcWords,
-        translatedLyric: "",
-        romanLyric: "",
-        startTime: lrcWords[0].startTime,
-        endTime: lrcWords[lrcWords.length - 1].endTime,
-        isBG: detectBackgroundLine(lrcWords, detectBackground),
-        isDuet: false,
-      });
-      continue;
-    }
-    // 回退标准整行模式
-    const lineWords = [{ startTime: 0, endTime: 0, word: content.trim() }];
-    const isBG = detectBackgroundLine(lineWords, detectBackground);
-    for (const t of times) {
-      lines.push({
-        words: [{ startTime: t, endTime: 0, word: lineWords[0].word }],
-        translatedLyric: "",
-        romanLyric: "",
-        startTime: t,
-        endTime: 0,
-        isBG,
-        isDuet: false,
-      });
-    }
+  for (const rawLine of text.split("\n")) {
+    lines.push(...parseLrcLine(rawLine, detectBackground));
   }
   // 按起始时间排序
   lines.sort((a, b) => a.startTime - b.startTime);
@@ -228,5 +258,11 @@ export const parseLRC = (text: string, detectBackground = true): LyricLine[] => 
     }
     lastStartTime = line.startTime;
   }
-  return merged;
+  return merged.filter(
+    (line) =>
+      line.words
+        .map((w) => w.word)
+        .join("")
+        .trim() !== "",
+  );
 };


### PR DESCRIPTION
## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

重构 `parseLRC.ts`，并
 - #118
 - #120 要求保留空白行。但实际不需要保留空白行，保留结束的时间戳即可
 - 支持尾随背景行识别

## 测试情况

已在本地测试

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
