### PR TITLE
fix(build): 修复 postinstall 脚本以确保 Electron 安装

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start": "electron-vite preview",
     "dev": "pnpm build:native --dev && tsx scripts/dev.ts",
     "build": "rimraf dist && pnpm build:native && pnpm typecheck && electron-vite build",
-    "postinstall": "electron-rebuild -f -w better-sqlite3",
+    "postinstall": "electron-rebuild -f -w better-sqlite3 && node node_modules/electron/install.js",
     "build:unpack": "pnpm build && electron-builder --dir --config electron-builder.config.ts",
     "build:win": "pnpm build && tsx scripts/gen-license.ts && electron-builder --config electron-builder.config.ts --win",
     "build:mac": "pnpm build && electron-builder --config electron-builder.config.ts --mac",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start": "electron-vite preview",
     "dev": "pnpm build:native --dev && tsx scripts/dev.ts",
     "build": "rimraf dist && pnpm build:native && pnpm typecheck && electron-vite build",
-    "postinstall": "electron-rebuild -f -w better-sqlite3 && node node_modules/electron/install.js",
+    "postinstall": "node node_modules/electron/install.js && electron-rebuild -f -w better-sqlite3",
     "build:unpack": "pnpm build && electron-builder --dir --config electron-builder.config.ts",
     "build:win": "pnpm build && tsx scripts/gen-license.ts && electron-builder --config electron-builder.config.ts --win",
     "build:mac": "pnpm build && electron-builder --config electron-builder.config.ts --mac",


### PR DESCRIPTION
- 在 postinstall 脚本中添加执行 electron/install.js 的步骤
- 确保 better-sqlite3 模块重建后 Electron 正确安装
- 改善构建流程的依赖完整性与稳定性

## 改动类型

- [ ] 新功能（feat）
- [X] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [X] 否

## 自查清单

- [X] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [X] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [X] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [X] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [X] 已向 `dev` 分支提交
