### PR TITLE
feat: 批量下载时尽快加入下载队列

### DIFF
--- a/src/composables/useDownload.ts
+++ b/src/composables/useDownload.ts
@@ -1,10 +1,5 @@
 import type { Track } from "@shared/types/player";
-import type {
-  DownloadRequest,
-  DownloadTagOptions,
-  DownloadStatus,
-  DownloadTask,
-} from "@shared/types/download";
+import type { DownloadRequest, DownloadTagOptions, DownloadTask } from "@shared/types/download";
 import { QUALITY_LABELS, type QualityLevel } from "@/utils/quality";
 import { useSettingsStore } from "@/stores/settings";
 import { resolveDownloadSource } from "@/services/downloadSource";
@@ -18,13 +13,15 @@ interface EnqueueOptions {
   quality?: QualityLevel;
   /** 复用已有任务 id（重试） */
   taskId?: string;
+  /** 禁用多余提示 */
+  quiet?: boolean;
 }
-
-const isTerminal = (status: DownloadStatus): boolean =>
-  status !== "queued" && status !== "downloading";
 
 /** 可下载音质档位（展示顺序） */
 const DOWNLOAD_QUALITY_LEVELS: QualityLevel[] = ["hi-res", "lossless", "hq", "sq", "lq"];
+
+/** 解析下载地址时间间隔 */
+const BATCH_RESOLVE_INTERVAL_MS = 500;
 
 /**
  * 构建下载音质菜单项
@@ -118,38 +115,32 @@ export const useDownload = () => {
       );
       return false;
     }
-    if (opts.taskId === undefined) toast.success(t("download.started", { title: track.title }));
+    if (opts.taskId === undefined && !opts.quiet)
+      toast.success(t("download.started", { title: track.title }));
     return true;
   };
 
-  /** 解析→下载→等待该任务结束（先订阅终态再发起，避免极快任务漏掉事件） */
-  const downloadAndWait = (track: Track): Promise<void> =>
-    prepareRequest(track, {}).then((req) => {
-      if (!req) return;
-      return new Promise<void>((resolve) => {
-        const off = window.api.download.onState((task) => {
-          if (task.taskId === req.taskId && isTerminal(task.status)) {
-            off();
-            resolve();
-          }
-        });
-        void window.api.download.start(req).then((res) => {
-          if (!res.ok) {
-            off();
-            resolve();
-          }
-        });
-      });
-    });
-
-  /** 批量下载：严格逐首 */
+  /** 批量下载：每秒解析并加入2个曲目防止触碰网易云API频率上限 */
   const enqueueMany = async (tracks: Track[]): Promise<void> => {
     const downloadable = tracks.filter((track) => track.source !== "local");
     if (downloadable.length === 0) return;
-    toast.success(t("download.enqueued", { count: downloadable.length }));
-    for (const track of downloadable) {
-      await downloadAndWait(track);
+    let successCount = 0;
+    for (const [index, track] of downloadable.entries()) {
+      const success = await enqueue(track, { quiet: true });
+      if (success) successCount++;
+      if (index < downloadable.length - 1) {
+        if (success)
+          toast.info(
+            t("download.enqueuing", {
+              title: track.title,
+              count: successCount,
+              total: downloadable.length,
+            }),
+          );
+        await new Promise((resolve) => setTimeout(resolve, BATCH_RESOLVE_INTERVAL_MS));
+      }
     }
+    toast.success(t("download.enqueued", { count: successCount, total: downloadable.length }));
   };
 
   /** 重试：用任务保存的完整 Track 重新解析并入队 */

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -664,7 +664,8 @@
     "alreadyQueued": "Already in the download queue",
     "alreadyDownloaded": "Already downloaded",
     "started": "Added to downloads: {title}",
-    "enqueued": "Added {count} to downloads",
+    "enqueued": "Added {count} tracks among total of {total} to downloads",
+    "enqueuing": "Added {title} to downloads ({count}/{total})",
     "status": {
       "queued": "Queued",
       "downloading": "Downloading",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -652,7 +652,8 @@
     "alreadyQueued": "该歌曲已在下载队列",
     "alreadyDownloaded": "该歌曲已下载",
     "started": "已加入下载：{title}",
-    "enqueued": "已加入 {count} 首下载",
+    "enqueued": "已加入 {total} 首中的 {count} 首到下载",
+    "enqueuing": "已加入 {title} 到下载（{count}/{total}）",
     "status": {
       "queued": "排队中",
       "downloading": "下载中",


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

以往的批量下载是逐个解析、加入队列、下载，一首曲目下载完毕再解析下一个，导致队列中始终只显示正在下载的一个曲目而不是显示所有排队曲目。现在改为逐个解析、加入队列，不等待上一首下载完毕，从而在队列中正确显示排队曲目。另外通过500ms的延迟避免高频率访问线上平台API导致封号。

## 关联

#95 

## 测试情况

下载歌单后可以看到底部弹出实时进度提醒，在下载管理页面可以看到曲目被一首首加入并排队下载。

## 截图 / 录屏

https://github.com/user-attachments/assets/cd1e55a2-947e-4d04-89fa-9e7d148c7fbc

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`（未涉及原生模块）
- [x] 已向 `dev` 分支提交
