### PR TITLE
feat: 自定义批量下载目录

### DIFF
--- a/electron/main/database/downloads.ts
+++ b/electron/main/database/downloads.ts
@@ -15,6 +15,7 @@ interface RawRow {
   tag_warning: number;
   created_at: number;
   finished_at: number | null;
+  custom_dir: string | null;
 }
 
 /** sqlite 行 → 业务 DownloadTask */
@@ -30,6 +31,7 @@ const toTask = (raw: RawRow): DownloadTask => ({
   tagWarning: raw.tag_warning === 1,
   createdAt: raw.created_at,
   finishedAt: raw.finished_at ?? undefined,
+  customDir: raw.custom_dir ?? undefined,
 });
 
 /** 写入或覆盖一条任务 */
@@ -37,8 +39,8 @@ export const upsert = (task: DownloadTask): void => {
   getDb()
     .prepare(
       `INSERT INTO download_tasks
-         (task_id, track_json, quality_level, status, received, total, file_path, error_code, tag_warning, created_at, finished_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         (task_id, track_json, quality_level, status, received, total, file_path, error_code, tag_warning, created_at, finished_at, custom_dir)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(task_id) DO UPDATE SET
          track_json = excluded.track_json,
          quality_level = excluded.quality_level,
@@ -48,7 +50,8 @@ export const upsert = (task: DownloadTask): void => {
          file_path = excluded.file_path,
          error_code = excluded.error_code,
          tag_warning = excluded.tag_warning,
-         finished_at = excluded.finished_at`,
+         finished_at = excluded.finished_at,
+         custom_dir = excluded.custom_dir`,
     )
     .run(
       task.taskId,
@@ -62,6 +65,7 @@ export const upsert = (task: DownloadTask): void => {
       task.tagWarning ? 1 : 0,
       task.createdAt,
       task.finishedAt ?? null,
+      task.customDir ?? null,
     );
 };
 

--- a/electron/main/database/index.ts
+++ b/electron/main/database/index.ts
@@ -133,7 +133,8 @@ export const initDatabase = (): void => {
       error_code TEXT,
       tag_warning INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL,
-      finished_at INTEGER
+      finished_at INTEGER,
+      custom_dir TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_download_tasks_created ON download_tasks(created_at);
 

--- a/electron/main/database/migration.ts
+++ b/electron/main/database/migration.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 
 /** 当前 schema 版本 */
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 
 type TableInfoRow = { name: string };
 
@@ -50,6 +50,14 @@ export const migrate = (d: Database.Database): void => {
       d.exec("ALTER TABLE tracks ADD COLUMN cue_end_ms INTEGER");
     }
     v = 4;
+  }
+
+  // v4 → v5: 添加下载任务自定义目录列
+  if (v < 5) {
+    if (!hasColumn(d, "download_tasks", "custom_dir")) {
+      d.exec("ALTER TABLE download_tasks ADD COLUMN custom_dir TEXT");
+    }
+    v = 5;
   }
 
   // 版本无关部分

--- a/electron/main/ipc/system.ts
+++ b/electron/main/ipc/system.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, shell } from "electron";
+import { app, ipcMain, dialog, shell } from "electron";
 import { writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, basename } from "node:path";
@@ -36,6 +36,19 @@ export const registerSystemIpc = (): void => {
   // 在文件管理器中显示文件
   ipcMain.handle("system:showInExplorer", (_event, filePath: string) => {
     shell.showItemInFolder(filePath);
+  });
+
+  // 选择目录
+  ipcMain.handle("system:pickDir", async (_event, title: string = "选择目录") => {
+    const result = await dialog.showOpenDialog({
+      title: title,
+      properties: ["openDirectory", "createDirectory"],
+    });
+    if (result.canceled || result.filePaths.length === 0) {
+      return { ok: false, reason: "canceled" as const };
+    }
+    const dir = result.filePaths[0];
+    return { ok: true, dir };
   });
 
   // 打开日志目录

--- a/electron/main/services/downloadManager.ts
+++ b/electron/main/services/downloadManager.ts
@@ -81,9 +81,9 @@ const resolutionGates = new Map<string, ResolutionGate>();
 /** 临时分片目录（与用户下载目录隔离） */
 const tmpDir = (): string => path.join(getAppCacheDir(), "downloads-tmp");
 
-/** 去重键：同一首歌同一档位只下一次 */
+/** 去重键：同一首歌同一档位同一位置只下一次 */
 const dedupeKeyOf = (req: DownloadRequest): string =>
-  `${req.track.source}:${req.track.id}:${req.qualityLevel}`;
+  `${req.track.source}:${req.track.id}:${req.qualityLevel}:${req.customDir ?? ""}`;
 
 /** 合并艺术家名 */
 const artistString = (req: DownloadRequest): string =>
@@ -271,7 +271,8 @@ const runTask = async (
         album: req.track.album?.name ?? "",
       },
     );
-    const targetDir = path.join(downloadDir, relDir);
+    // 若用户自定义了下载目录则直接采用
+    const targetDir = req.customDir ?? path.join(downloadDir, relDir);
     const finalNoExt = path.join(targetDir, baseName);
     const policy = store.get("download.overwritePolicy");
 
@@ -371,7 +372,10 @@ const enqueueOne = (
     completedByQuality?.set(req.qualityLevel, completed);
   }
   const downloaded = completed.find(
-    (task) => task.track.source === req.track.source && task.track.id === req.track.id,
+    (task) =>
+      task.track.source === req.track.source &&
+      task.track.id === req.track.id &&
+      (task.customDir ?? null) === (req.customDir ?? null),
   );
   if (downloaded?.filePath && fs.existsSync(downloaded.filePath)) {
     return { ok: false, reason: "downloaded" };
@@ -384,6 +388,7 @@ const enqueueOne = (
     received: 0,
     total: req.declaredSize ?? 0,
     createdAt: Date.now(),
+    customDir: req.customDir,
   };
   tasks.set(req.taskId, { req, task, controller: new AbortController(), dedupeKey });
   queue.push(req.taskId);

--- a/electron/preload/index.d.ts
+++ b/electron/preload/index.d.ts
@@ -48,6 +48,7 @@ declare global {
         };
         toggleDevTools: () => Promise<void>;
         showInExplorer: (filePath: string) => Promise<void>;
+        pickDir: (title?: string) => Promise<{ ok: boolean; dir?: string; reason?: "canceled" }>;
         openLogsDir: () => Promise<string>;
         setLocale: (locale: LocaleCode) => void;
         focusMainWindow: () => Promise<void>;

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -144,6 +144,8 @@ const api = {
     toggleDevTools: () => ipcRenderer.invoke("system:toggleDevTools"),
     // 在文件管理器中显示文件
     showInExplorer: (filePath: string) => ipcRenderer.invoke("system:showInExplorer", filePath),
+    // 选择目录
+    pickDir: (title?: string) => ipcRenderer.invoke("system:pickDir", title),
     // 打开日志目录
     openLogsDir: () => ipcRenderer.invoke("system:openLogsDir"),
     // 同步语言到主进程

--- a/shared/types/download.ts
+++ b/shared/types/download.ts
@@ -53,6 +53,8 @@ export interface DownloadRequest {
   usePlaybackForDownload: boolean;
   /** 内嵌歌词与 .lrc 的保存格式 */
   lyricFileFormat: DownloadLyricFormat;
+  /** 自定义下载目录 */
+  customDir?: string;
 }
 
 /** 主进程持有的下载任务 */
@@ -73,6 +75,8 @@ export interface DownloadTask {
   tagWarning?: boolean;
   createdAt: number;
   finishedAt?: number;
+  /** 自定义下载目录 */
+  customDir?: string;
 }
 
 /** 下载进度推送 */

--- a/src/components/list/SongList.vue
+++ b/src/components/list/SongList.vue
@@ -23,6 +23,7 @@ import IconLucideListEnd from "~icons/lucide/list-end";
 import IconLucideListPlus from "~icons/lucide/list-plus";
 import IconLucideListMinus from "~icons/lucide/list-minus";
 import IconLucideDownload from "~icons/lucide/download";
+import IconLucideFolderDown from "~icons/lucide/folder-down";
 import IconLucideTrash2 from "~icons/lucide/trash-2";
 import IconLucideArrowLeftRight from "~icons/lucide/arrow-left-right";
 import IconLucideX from "~icons/lucide/x";
@@ -373,6 +374,16 @@ defineExpose({
               >
                 <template #icon><IconLucideDownload class="size-3.5" /></template>
                 <span>{{ t("songList.batch.download") }}</span>
+              </SButton>
+              <SButton
+                v-if="source !== 'local' && settings.system.download.enabled"
+                variant="ghost"
+                size="small"
+                :disabled="batch.selectedCount.value === 0"
+                @click="batch.batchDownloadCustomDir"
+              >
+                <template #icon><IconLucideFolderDown class="size-3.5" /></template>
+                <span>{{ t("songList.batch.downloadCustomDir") }}</span>
               </SButton>
               <SButton
                 v-if="source === 'local' || source === 'netease'"

--- a/src/composables/useDownload.ts
+++ b/src/composables/useDownload.ts
@@ -10,6 +10,8 @@ interface EnqueueOptions {
   quality?: QualityLevel;
   /** 复用已有任务 id（重试） */
   taskId?: string;
+  /** 自定义下载目录 */
+  customDir?: string;
 }
 
 /** 可下载音质档位（展示顺序） */
@@ -57,6 +59,7 @@ export const useDownload = () => {
       tagOptions,
       usePlaybackForDownload: download.usePlaybackForDownload,
       lyricFileFormat: download.lyricFileFormat,
+      customDir: opts.customDir,
     };
   };
 
@@ -92,7 +95,11 @@ export const useDownload = () => {
 
   /** 重试：用任务保存的完整 Track 重新入队（复用 taskId） */
   const retry = (task: DownloadTask): Promise<boolean> =>
-    enqueue(task.track, { quality: task.qualityLevel, taskId: task.taskId });
+    enqueue(task.track, {
+      quality: task.qualityLevel,
+      taskId: task.taskId,
+      customDir: task.customDir,
+    });
 
   return { enqueue, enqueueMany, retry };
 };

--- a/src/composables/useDownload.ts
+++ b/src/composables/useDownload.ts
@@ -84,9 +84,9 @@ export const useDownload = () => {
   };
 
   /** 批量下载 */
-  const enqueueMany = async (tracks: Track[]): Promise<void> => {
+  const enqueueMany = async (tracks: Track[], opts: EnqueueOptions = {}): Promise<void> => {
     const requests = tracks
-      .map((track) => prepareRequest(track, {}))
+      .map((track) => prepareRequest(track, opts))
       .filter((req): req is DownloadRequest => req !== null);
     const results = await window.api.download.startMany(requests).catch(() => []);
     const count = results.filter((result) => result?.ok).length;

--- a/src/composables/useMultiSelect.ts
+++ b/src/composables/useMultiSelect.ts
@@ -199,6 +199,17 @@ export const useMultiSelect = (items: Ref<Track[]>, options: MultiSelectOptions)
     exit();
   };
 
+  /** 批量下载到自定义目录 */
+  const batchDownloadCustomDir = async (): Promise<void> => {
+    const result = await window.api.system.pickDir("选择下载目录");
+    if (result.ok) {
+      const tracks = selectedItems.value.filter((track) => track.source !== "local");
+      if (tracks.length === 0) return;
+      void enqueueMany(tracks, { customDir: result.dir });
+      exit();
+    }
+  };
+
   return {
     // 选择状态
     active,
@@ -231,5 +242,6 @@ export const useMultiSelect = (items: Ref<Track[]>, options: MultiSelectOptions)
     batchDelete,
     batchRemoveFromCloud,
     batchDownload,
+    batchDownloadCustomDir,
   };
 };

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -553,6 +553,7 @@
       "invert": "Invert",
       "addToQueue": "Add to Queue",
       "download": "Batch Download",
+      "downloadCustomDir": "Download to Custom Directory",
       "exit": "Exit"
     },
     "delete": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -541,6 +541,7 @@
       "invert": "反选",
       "addToQueue": "添加到播放列表",
       "download": "批量下载",
+      "downloadCustomDir": "下载到自定义目录",
       "exit": "退出"
     },
     "delete": {


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

提供“下载到自定义目录”功能，直接选择目录并批量下载，无需改动设置。
为了提供相关功能，把自定义目录纳入了持久化数据库的下载任务表中，因此进行了数据库升级和迁移。

## 关联

Inspired by: #95 

## 测试情况

进入任意线上专辑，进入批量编辑模式，可以看到“下载到自定义目录”，点击后弹出系统文件夹选择框，选择后确认即开始下载到该文件夹。

## 截图 / 录屏

https://github.com/user-attachments/assets/61b66cbb-b7e5-45da-b083-9b37355aa6a6

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`（未涉及原生模块）
- [x] 已向 `dev` 分支提交
