### PR TITLE
fix: 修复 resolveByPlugin 函数参数描述，确保音质档位由调用方传入

### DIFF
--- a/src/services/audioSource.ts
+++ b/src/services/audioSource.ts
@@ -69,7 +69,7 @@ export type OnlineResolveResult =
 /**
  * 经插件解析在线音频源 URL
  * @param track - 要解析的 track
- * @param quality - 音质档位（播放默认 hq，下载传下载档位）
+ * @param quality - 音质档位（由调用方传入，默认 hq）
  * @returns 解析结果，失败时带原因码
  */
 export const resolveByPlugin = async (
@@ -171,7 +171,7 @@ const resolveOnlineUrl = async (
       officialErrorCode = ErrorCode.URL_RESOLVE_FAILED;
     }
   }
-  const pluginResolved = await resolveByPlugin(track, "hq", options.skipPluginIds ?? []);
+  const pluginResolved = await resolveByPlugin(track, songLevel, options.skipPluginIds ?? []);
   if (pluginResolved.ok) return pluginResolved;
   if (trialUrl && settings.player.allowTrialPlay) {
     return { ok: true, url: trialUrl, isTrial: true, provider: "trial" };


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

修复插件音源在请求 URL 时音质被硬编码为 `"hq"` 的问题（#180）。

`src/services/audioSource.ts` 中的 `resolveOnlineUrl` 函数在兜底调用插件解析时，传入了写死的 `"hq"` 作为音质参数，忽略了用户通过设置页面选择的 `songLevel`（如无损 / Hi-Res）。导致即使设置了高音质档位，插件仍只会请求 HQ 档的音频链接。

本次改动将硬编码的 `"hq"` 替换为 `songLevel`，使插件音源与官方接口行为一致，均可正确响应用户的音质设置。

**主要变更：**
- `src/services/audioSource.ts` 第 174 行：`resolveByPlugin(track, "hq", ...)` → `resolveByPlugin(track, songLevel, ...)`

## 关联 Issue

Fix #180

## 测试情况

- 手动验证：将设置中音质档位切换为 lossless / hi-res，播放网易云/QQ音乐来源的歌曲，确认插件音源请求携带的 quality 参数与设置一致。
- 下载路径不受影响（`downloadSource.ts` 调用 `resolveByPlugin` 时已正确传入 level）。

## 自查清单

- [x] 本 PR 只包含一个主要修复，没有夹带无关改动
- [x] 已在本地完整测试通过；AI 生成的代码同样自行测试并审阅过
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 未改动原生模块
- [x] 已向 `dev` 分支提交