### PR TITLE
fix: Windows 下多显示器不同缩放比例时窗口恢复尺寸异常

### DIFF
--- a/electron/main/window/main.ts
+++ b/electron/main/window/main.ts
@@ -9,6 +9,7 @@ import { store } from "@main/store";
 import { handleCacheProtocolOnPartition, MAIN_PARTITION } from "@main/utils/protocol";
 import { isAppQuitting } from "@main/utils/lifecycle";
 import { broadcast } from "@main/utils/broadcast";
+import { isWin } from "@main/utils/config";
 import { CURRENT_AGREEMENT_VERSION } from "@shared/constants/agreement";
 
 /** 判断是否应用内部导航 */
@@ -41,6 +42,16 @@ export const createMainWindow = (): BrowserWindow => {
       webgl: true,
     },
   });
+
+  // Electron 43 在混合 DPI 下会先按主屏缩放创建窗口，定位到目标屏幕后需重新应用边界
+  if (isWin && saved?.x != null && saved?.y != null) {
+    mainWindow.setBounds({
+      width: saved.width,
+      height: saved.height,
+      x: saved.x,
+      y: saved.y,
+    });
+  }
 
   // 恢复最大化状态
   if (remember && saved?.maximized) {


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

Electron 43.2.0 在 Windows 混合 DPI 环境中恢复带保存坐标的窗口时，会先按主显示器 DPI 初始化窗口尺寸，再将窗口定位到目标副屏。当两块显示器的缩放比例不同时，首次 DIP 到物理像素的换算会采用错误的缩放比例，导致重新启动后窗口变小或变大，并可能在连续重启后累积偏差。

本 PR 在主窗口创建并定位到目标显示器后、恢复最大化状态前，再次调用 `setBounds` 应用保存的窗口边界，使尺寸按照目标显示器的 DPI 重新换算。

该兼容逻辑仅在 Windows 且存在完整保存坐标时执行，不修改设置结构，不影响首次启动、未开启“记忆窗口状态”的场景以及 macOS、Linux 的现有行为。

## 关联 Issue

<!-- 如有关联，填 #编号；写 "Closes #编号" 可在合并时自动关闭对应 Issue -->

## 测试情况

- 测试环境：Windows 11，多显示器混合 DPI，`SPlayer-Next-1.0.0-x64-portable.exe`。
- 已验证窗口位于非主显示器时，退出并重新启动后位置和尺寸保持一致。
- 已验证连续多次退出和重新启动后，窗口尺寸不会累积缩小或放大。
- 测试步骤
    1. 在 Windows 11 中连接至少两台显示器，并让主显示器与目标副屏使用不同的缩放比例，例如主屏 100%、副屏 125%。
    2. 启动 `SPlayer-Next-1.0.0-x64-portable.exe`。
    3. 在设置中开启“记忆窗口状态”。
    4. 将 SPlayer 主窗口移动到非主显示器，并调整窗口大小。
    5. 完全退出 SPlayer。
    6. 再次启动 SPlayer。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
