### PR TITLE
fix: 输出设备失效时回退到系统默认设备

### DIFF
--- a/native/audio-engine/src/audio_output.rs
+++ b/native/audio-engine/src/audio_output.rs
@@ -147,20 +147,30 @@ fn build_output_sink(device_name: Option<&str>) -> Result<(MixerDeviceSink, u32)
             let device = host
                 .output_devices()
                 .context("Failed to enumerate output devices")?
-                .find(|device| persisted_device_name(device).as_deref() == Some(name))
-                .with_context(|| format!("Output device '{}' not found", name))
-                .with_audio_kind(AudioErrorKind::Device)?;
-            open_device_with_default_config(&device)
+                .find(|device| persisted_device_name(device).as_deref() == Some(name));
+            match device {
+                Some(device) => open_device_with_default_config(&device).or_else(|error| {
+                    warn!(device = name, error = %error, "指定设备打开失败，回退到系统默认设备");
+                    open_default_sink()
+                }),
+                None => {
+                    warn!(device = name, "指定设备不存在，回退到系统默认设备");
+                    open_default_sink()
+                }
+            }
         }
-        None => {
-            let sink = DeviceSinkBuilder::open_default_sink()
-                .context("Failed to open default output device")
-                .with_audio_kind(AudioErrorKind::Device)?;
-            let sample_rate = sink.config().sample_rate().get();
-            info!(sample_rate, "使用系统默认音频输出配置");
-            Ok((sink, sample_rate))
-        }
+        None => open_default_sink(),
     }
+}
+
+/// 使用系统默认设备创建输出流
+fn open_default_sink() -> Result<(MixerDeviceSink, u32)> {
+    let sink = DeviceSinkBuilder::open_default_sink()
+        .context("Failed to open default output device")
+        .with_audio_kind(AudioErrorKind::Device)?;
+    let sample_rate = sink.config().sample_rate().get();
+    info!(sample_rate, "使用系统默认音频输出配置");
+    Ok((sink, sample_rate))
 }
 
 /// 设备名已被设置持久化为选择键，继续沿用旧 API 的值以避免升级后已有配置失效


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

当用户手动指定的音频输出设备（例如 USB 耳机）被拔掉或失效时，`native/audio-engine/src/audio_output.rs` 的 `build_output_sink` 原本会直接报错 `Output device not found`。由于 `recreate_output_device` 中旧输出流已 `take()` 丢弃，重建失败后播放器失去音频输出，用户只能在「设置」页手动把设备切回「跟随系统默认」，播放期间设备热插拔体验很差（对应 issue #179）。

本 PR 将「指定设备」分支改为：设备未找到或指定设备打开失败时，记录 `warn` 日志并回退到系统默认输出设备（复用 `open_default_sink`），保证热插拔场景下声音能自动切到可用设备。

该 fallback 仅发生在指定设备失效时，不影响正常指定设备、首次打开、无可用设备时的原有报错路径，不修改设置结构与 IPC 接口。

## 关联 Issue

Closes #179

## 测试情况

- 测试环境：当前开发机（Windows，无可用音频输出设备热插拔实测条件）。
- 已通过本地审阅确认：`open_device_with_default_config` 的 `?` 失败路径与 `.find` 未命中路径均能正确落到 `open_default_sink`；`warn!` 宏已在该文件导入；`open_default_sink` 与原有 `None` 分支逻辑完全一致。
- 受环境限制，**未能在真实设备热插拔场景下运行 `pnpm build:native` 与实机测试**，建议尝试合并或 CI 通过后再在 Windows 上验证：
  1. 在「设置」中选择 USB 耳机作为输出设备。
  2. 播放状态中拔掉 USB 耳机。
  3. 确认声音自动切到系统默认设备（音箱），无需进入设置页手动切换，且日志出现对应 `warn` 记录。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [ ] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [ ] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交