### PR TITLE
fix: 修复 media-ctrl 对音量和播放速度的行为

### DIFF
--- a/electron/main/ipc/player.ts
+++ b/electron/main/ipc/player.ts
@@ -136,6 +136,7 @@ const registerNativeEvents = (inst: InstanceType<AudioEngineModule["AudioPlayer"
             position: toDisplayPositionMs(toMs(inst.getPosition())),
             duration: toDisplayDurationMs(toMs(inst.getDuration())),
             volume: inst.getVolume(),
+            speed: inst.getSpeed(),
             isFinished: false,
           },
         };
@@ -226,6 +227,7 @@ export const registerPlayerIpc = (): void => {
           position: 0,
           duration: 0,
           volume: inst.getVolume(),
+          speed: inst.getSpeed(),
           isFinished: false,
         },
       };
@@ -442,6 +444,7 @@ export const registerPlayerIpc = (): void => {
         position: toDisplayPositionMs(toMs(raw.position)),
         duration: toDisplayDurationMs(toMs(raw.duration)),
         volume: raw.volume,
+        speed: getPlayer().getSpeed(),
         isFinished: raw.isFinished,
       },
     };
@@ -504,6 +507,7 @@ export const registerPlayerIpc = (): void => {
   ipcMain.handle("player:setSpeed", (_event, speed: number) => {
     try {
       getPlayer().setSpeed(speed);
+      mediaService.setRate(speed);
       nowPlaying.onSpeedChange(speed);
       return { success: true };
     } catch (error) {
@@ -677,7 +681,45 @@ export const registerPlayerIpc = (): void => {
           break;
         case "SetVolume":
           if (event.volume != null) {
-            inst.setVolume(event.volume);
+            if (0 <= event.volume && event.volume <= 1) {
+              inst.setVolume(event.volume);
+              mediaService.setVolume(event.volume);
+              sendToMain("player:event", {
+                type: "status",
+                data: {
+                  state: inst.getStatus().state as PlayerState,
+                  position: toDisplayPositionMs(toMs(inst.getPosition())),
+                  duration: toDisplayDurationMs(toMs(inst.getDuration())),
+                  volume: event.volume,
+                  speed: inst.getSpeed(),
+                  isFinished: false,
+                },
+              });
+            } else {
+              playerLog.warn(`无效的音量值: ${event.volume}`);
+            }
+          }
+          break;
+        case "SetRate":
+          if (event.rate != null) {
+            if (0.5 <= event.rate && event.rate <= 2.0) {
+              inst.setSpeed(event.rate);
+              mediaService.setRate(event.rate);
+              nowPlaying.onSpeedChange(event.rate);
+              sendToMain("player:event", {
+                type: "status",
+                data: {
+                  state: inst.getStatus().state as PlayerState,
+                  position: toDisplayPositionMs(toMs(inst.getPosition())),
+                  duration: toDisplayDurationMs(toMs(inst.getDuration())),
+                  volume: inst.getVolume(),
+                  speed: event.rate,
+                  isFinished: false,
+                },
+              });
+            } else {
+              playerLog.warn(`无效的播放速率值: ${event.rate}`);
+            }
           }
           break;
         case "NextTrack":
@@ -712,7 +754,7 @@ export const registerPlayerIpc = (): void => {
     stopDeviceMonitoring();
     const stoppedEvent = {
       type: "status",
-      data: { state: "stopped", position: 0, duration: 0, volume: 1, isFinished: false },
+      data: { state: "stopped", position: 0, duration: 0, volume: 1, speed: 1, isFinished: false },
     };
     sendToMain("player:event", stoppedEvent);
     wsBroadcast(stoppedEvent);

--- a/native/media-ctrl/src/sys_media/linux.rs
+++ b/native/media-ctrl/src/sys_media/linux.rs
@@ -287,7 +287,7 @@ async fn run_mpris_loop(
     let mut cover_guard: Option<NamedTempFile> = None;
 
     let pid = process::id();
-    let identity = format!("splayer-next.instance{pid}");
+    let identity = format!("splayer_next.instance{pid}");
 
     let player = Player::builder(&identity)
         .can_play(true)
@@ -296,7 +296,7 @@ async fn run_mpris_loop(
         .can_go_previous(true)
         .can_seek(true)
         .can_control(true)
-        .minimum_rate(0.2)
+        .minimum_rate(0.5)
         .maximum_rate(2.0)
         .playback_status(MprisPlaybackStatus::Stopped)
         .identity("SPlayer-Next")

--- a/shared/types/player.ts
+++ b/shared/types/player.ts
@@ -182,6 +182,7 @@ export interface PlayerStatus {
   position: number;
   duration: number;
   volume: number;
+  speed: number;
   isFinished: boolean;
 }
 

--- a/src/core/player/events.ts
+++ b/src/core/player/events.ts
@@ -69,6 +69,10 @@ export const handleEvent = async (event: PlayerEvent): Promise<void> => {
       }
       status.duration = event.data.duration;
       status.volume = event.data.volume;
+      if (event.data.speed != null) {
+        status.speed = event.data.speed;
+        playback.setSpeed(event.data.speed);
+      }
       playback.setDuration(event.data.duration);
       playback.setPlaying(event.data.state === "playing");
       break;


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

 - 系统媒体事件处理新增 `SetRate`
 - 系统媒体事件处理中，`SetVolume` 和 `SetRate` 的值分别通知 `mediaService` 和前端
 - 为了将 `SetRate` 的值传回前端，在 `PlayerStatus` 中新增 `speed` 字段，并增加对应的处理
 - `media-ctrl` 的 `linux.rs` 中：`minimum_rate` 同步为项目的 `0.5`；`identity` 中的连字符替换为下划线（见[此](https://github.com/SPlayer-Dev/SPlayer-Next/discussions/33#discussioncomment-17880673)）

## 测试情况

在 Arch Linux 上，使用 KDE Plasma Wayland 和 dms-shell-niri (嵌套合成器) 上测试通过

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
