### PR TITLE
feat: 插件歌词优先偏好配置 & 音源插件图形化配置

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,6 @@ export default defineConfig(
     "**/.vitepress/",
     "native/*/index.d.ts",
     ".github/scripts/",
-    "plugins/",
   ]),
   tseslint.configs.recommended,
   { languageOptions: { globals: autoImports.globals } },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default defineConfig(
     "**/.vitepress/",
     "native/*/index.d.ts",
     ".github/scripts/",
+    "plugins/",
   ]),
   tseslint.configs.recommended,
   { languageOptions: { globals: autoImports.globals } },

--- a/src/components/settings/custom/PluginList.vue
+++ b/src/components/settings/custom/PluginList.vue
@@ -25,8 +25,8 @@ onMounted(() => {
   if (!loaded.value) void pluginsStore.load();
 });
 
-/** 控制类插件 ready 时声明的设置 schema（配置弹窗用） */
-const controlSettings = (info: PluginInfo) => {
+/** 插件 ready 时声明的设置 schema（配置弹窗用） */
+const pluginSettings = (info: PluginInfo) => {
   if (info.status.state !== "ready") return [];
   return info.status.settings ?? [];
 };
@@ -132,13 +132,15 @@ const onSettingChange = async (pluginId: string, key: string, value: unknown): P
   await pluginsStore.setSetting(pluginId, key, value);
 };
 
-/** 当前打开配置弹窗的控制类插件 */
-const settingsDialogInfo = computed(
-  () => controlPlugins.value.find((info) => info.manifest.id === settingsDialogId.value) ?? null,
-);
+/** 当前打开配置弹窗的插件（支持音源类与控制类） */
+const settingsDialogInfo = computed(() => {
+  if (!settingsDialogId.value) return null;
+  const allPlugins = [...sourcePlugins.value, ...controlPlugins.value];
+  return allPlugins.find((info) => info.manifest.id === settingsDialogId.value) ?? null;
+});
 /** 弹窗内设置表单的 schema 与当前值 */
 const settingsDialogSchema = computed(() =>
-  settingsDialogInfo.value ? controlSettings(settingsDialogInfo.value) : [],
+  settingsDialogInfo.value ? pluginSettings(settingsDialogInfo.value) : [],
 );
 const settingsDialogValues = computed(() => settingsDialogInfo.value?.settingsValues ?? {});
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -931,7 +931,7 @@
     },
     "preferPluginLyric": {
       "label": "Prefer Plugin Lyrics",
-      "description": "Query plugins first and fall back to built-in platforms on a miss; when off, plugins are only a last resort"
+      "description": "Request plugin lyrics concurrently and auto-replace if a higher-ranked format is returned"
     },
     "detectBackgroundLyrics": {
       "label": "Auto-Detect Background Lyrics",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -929,6 +929,10 @@
       "label": "Auto-Upgrade Lyric Format",
       "description": "Fetch a higher-ranked format from other platforms when the current one is low"
     },
+    "preferPluginLyric": {
+      "label": "Prefer Plugin Lyrics",
+      "description": "Query plugins first and fall back to built-in platforms on a miss; when off, plugins are only a last resort"
+    },
     "detectBackgroundLyrics": {
       "label": "Auto-Detect Background Lyrics",
       "description": "Detect backing vocals from brackets. Disable this if lyrics are misdetected"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -917,6 +917,10 @@
       "label": "自动升级歌词格式",
       "description": "当前歌词格式较低时，从其他平台获取更高级的格式覆盖"
     },
+    "preferPluginLyric": {
+      "label": "优先使用插件歌词",
+      "description": "开启后先向插件请求歌词，未命中再回落到内置平台；关闭时插件仅作为兜底"
+    },
     "detectBackgroundLyrics": {
       "label": "自动识别背景歌词",
       "description": "根据括号识别背景人声，误判时可关闭"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -919,7 +919,7 @@
     },
     "preferPluginLyric": {
       "label": "优先使用插件歌词",
-      "description": "开启后先向插件请求歌词，未命中再回落到内置平台；关闭时插件仅作为兜底"
+      "description": "开启后同时请求插件歌词，若返回更优格式则自动替换"
     },
     "detectBackgroundLyrics": {
       "label": "自动识别背景歌词",

--- a/src/services/download/lyric.ts
+++ b/src/services/download/lyric.ts
@@ -12,6 +12,7 @@ import {
   resolveLocalRepoLyric,
   resolveOnlineByPreference,
   resolvePluginLyric,
+  resolvePreferredPluginLyric,
   resolveStreamingByPreference,
   resolveTTMLOverlay,
   type OnlineResult,
@@ -60,6 +61,9 @@ const resolveOnlineDownloadLyric = async (
 export const resolveDownloadLyric = async (track: Track): Promise<DownloadLyric | null> => {
   const local = toUsableDownloadLyric(await resolveLocalRepoLyric(track));
   if (local) return local;
+  // 插件首选
+  const preferredPlugin = toUsableDownloadLyric(await resolvePreferredPluginLyric(track));
+  if (preferredPlugin) return preferredPlugin;
   // 流媒体
   if (track.source === "streaming") {
     return (

--- a/src/services/download/lyric.ts
+++ b/src/services/download/lyric.ts
@@ -9,10 +9,11 @@ import type { LyricFormat, LyricInput } from "@shared/types/lyrics";
 import { isPlatform } from "@shared/types/platform";
 import { buildDownloadLyric } from "@/utils/lyric/serialize";
 import {
+  isBetterFormat,
+  isPluginLyricPreferred,
   resolveLocalRepoLyric,
   resolveOnlineByPreference,
   resolvePluginLyric,
-  resolvePreferredPluginLyric,
   resolveStreamingByPreference,
   resolveTTMLOverlay,
   type OnlineResult,
@@ -61,23 +62,54 @@ const resolveOnlineDownloadLyric = async (
 export const resolveDownloadLyric = async (track: Track): Promise<DownloadLyric | null> => {
   const local = toUsableDownloadLyric(await resolveLocalRepoLyric(track));
   if (local) return local;
-  // 插件首选
-  const preferredPlugin = toUsableDownloadLyric(await resolvePreferredPluginLyric(track));
-  if (preferredPlugin) return preferredPlugin;
+
+  const preferPlugin = isPluginLyricPreferred();
+
   // 流媒体
   if (track.source === "streaming") {
+    if (preferPlugin) {
+      const [streamingResolved, pluginResolved] = await Promise.all([
+        resolveStreamingByPreference(track),
+        resolvePluginLyric(track),
+      ]);
+      const streaming = toUsableDownloadLyric(streamingResolved);
+      const plugin = toUsableDownloadLyric(pluginResolved);
+      if (plugin && isBetterFormat(plugin.format, streaming?.format ?? null)) {
+        return plugin;
+      }
+      return streaming ?? plugin ?? null;
+    }
     return (
       toUsableDownloadLyric(await resolveStreamingByPreference(track)) ??
       toUsableDownloadLyric(await resolvePluginLyric(track))
     );
   }
+
   // 在线平台
   if (isPlatform(track.source)) {
+    if (preferPlugin) {
+      const [onlineLyric, pluginResolved] = await Promise.all([
+        (async () => {
+          const online = await resolveOnlineByPreference(track, {
+            hasLocal: false,
+            localFormat: null,
+          });
+          return resolveOnlineDownloadLyric(track, online);
+        })(),
+        resolvePluginLyric(track),
+      ]);
+      const plugin = toUsableDownloadLyric(pluginResolved);
+      if (plugin && isBetterFormat(plugin.format, onlineLyric?.format ?? null)) {
+        return plugin;
+      }
+      return onlineLyric ?? plugin ?? null;
+    }
     const online = await resolveOnlineByPreference(track, { hasLocal: false, localFormat: null });
     return (
       (await resolveOnlineDownloadLyric(track, online)) ??
       toUsableDownloadLyric(await resolvePluginLyric(track))
     );
   }
+
   return null;
 };

--- a/src/services/download/lyric.ts
+++ b/src/services/download/lyric.ts
@@ -63,52 +63,31 @@ export const resolveDownloadLyric = async (track: Track): Promise<DownloadLyric 
   const local = toUsableDownloadLyric(await resolveLocalRepoLyric(track));
   if (local) return local;
 
-  const preferPlugin = isPluginLyricPreferred();
-
   // 流媒体
   if (track.source === "streaming") {
-    if (preferPlugin) {
-      const [streamingResolved, pluginResolved] = await Promise.all([
-        resolveStreamingByPreference(track),
-        resolvePluginLyric(track),
-      ]);
-      const streaming = toUsableDownloadLyric(streamingResolved);
-      const plugin = toUsableDownloadLyric(pluginResolved);
-      if (plugin && isBetterFormat(plugin.format, streaming?.format ?? null)) {
-        return plugin;
-      }
+    // 插件优选：请求先行发出，与正常来源并发
+    const pluginTask = isPluginLyricPreferred() ? resolvePluginLyric(track) : null;
+    const streaming = toUsableDownloadLyric(await resolveStreamingByPreference(track));
+    if (pluginTask) {
+      const plugin = toUsableDownloadLyric(await pluginTask);
+      if (plugin && isBetterFormat(plugin.format, streaming?.format ?? null)) return plugin;
       return streaming ?? plugin ?? null;
     }
-    return (
-      toUsableDownloadLyric(await resolveStreamingByPreference(track)) ??
-      toUsableDownloadLyric(await resolvePluginLyric(track))
-    );
+    return streaming ?? toUsableDownloadLyric(await resolvePluginLyric(track));
   }
 
   // 在线平台
   if (isPlatform(track.source)) {
-    if (preferPlugin) {
-      const [onlineLyric, pluginResolved] = await Promise.all([
-        (async () => {
-          const online = await resolveOnlineByPreference(track, {
-            hasLocal: false,
-            localFormat: null,
-          });
-          return resolveOnlineDownloadLyric(track, online);
-        })(),
-        resolvePluginLyric(track),
-      ]);
-      const plugin = toUsableDownloadLyric(pluginResolved);
-      if (plugin && isBetterFormat(plugin.format, onlineLyric?.format ?? null)) {
-        return plugin;
-      }
+    // 插件优选：请求先行发出，与正常来源并发
+    const pluginTask = isPluginLyricPreferred() ? resolvePluginLyric(track) : null;
+    const online = await resolveOnlineByPreference(track, { hasLocal: false, localFormat: null });
+    const onlineLyric = await resolveOnlineDownloadLyric(track, online);
+    if (pluginTask) {
+      const plugin = toUsableDownloadLyric(await pluginTask);
+      if (plugin && isBetterFormat(plugin.format, onlineLyric?.format ?? null)) return plugin;
       return onlineLyric ?? plugin ?? null;
     }
-    const online = await resolveOnlineByPreference(track, { hasLocal: false, localFormat: null });
-    return (
-      (await resolveOnlineDownloadLyric(track, online)) ??
-      toUsableDownloadLyric(await resolvePluginLyric(track))
-    );
+    return onlineLyric ?? toUsableDownloadLyric(await resolvePluginLyric(track));
   }
 
   return null;

--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -11,10 +11,11 @@ import { useSettingsStore } from "@/stores/settings";
 import { DEFAULT_LYRIC_FORMAT_ORDER } from "@/types/settings";
 import {
   embeddedLyricFromDetail,
+  isBetterFormat,
+  isPluginLyricPreferred,
   resolveLocalRepoLyric,
   resolveOnlineByPreference,
   resolvePluginLyric,
-  resolvePreferredPluginLyric,
   resolveStreamingByPreference,
   resolveTTMLOverlay,
   type LocalLyric,
@@ -81,6 +82,21 @@ const commitResolvedAndHasParsed = (token: number, resolved: ResolvedLyric): boo
   commitAndHasParsed(token, resolved.source, resolved.input);
 
 /**
+ * 尝试提交已解析歌词；若当前已展示更优或同级格式则忽略
+ * @param token - 竞态 token
+ * @param resolved - 待提交的歌词候选
+ * @returns 是否成功提交且有有效行
+ */
+const commitIfBetter = (token: number, resolved: ResolvedLyric): boolean => {
+  if (token !== currentToken) return false;
+  const currentFormat = useMediaStore().activeLyric?.format ?? null;
+  if (!currentFormat || isBetterFormat(resolved.source.format, currentFormat)) {
+    return commitResolvedAndHasParsed(token, resolved);
+  }
+  return false;
+};
+
+/**
  * 提交在线歌词；解析后为空时优先回退本地，本地也无再按需 TTML 升级
  */
 const applyOnline = async (
@@ -91,17 +107,20 @@ const applyOnline = async (
 ): Promise<void> => {
   const media = useMediaStore();
   const current = media.activeLyric;
+  const currentFormat = current?.format ?? null;
   // 跳过同源同格式
   const alreadyCommitted =
     current?.source === "online" &&
     current.platform === online.source.platform &&
     current.format === online.source.format;
   if (!alreadyCommitted) {
-    if (!commitAndHasParsed(token, online.source, online.input) && fallbackLocal) {
-      commitLocal(token, fallbackLocal);
-      return;
+    if (!currentFormat || isBetterFormat(online.source.format, currentFormat)) {
+      if (!commitAndHasParsed(token, online.source, online.input) && fallbackLocal) {
+        commitLocal(token, fallbackLocal);
+        return;
+      }
+      if (token !== currentToken) return;
     }
-    if (token !== currentToken) return;
   } else if (media.parsedLyric.length === 0 && fallbackLocal) {
     commitLocal(token, fallbackLocal);
     return;
@@ -109,7 +128,7 @@ const applyOnline = async (
   const ttml = await resolveTTMLOverlay(track, online);
   if (token !== currentToken) return;
   if (ttml) {
-    commit(token, ttml.source, ttml.input);
+    commitIfBetter(token, ttml);
   }
 };
 
@@ -138,20 +157,8 @@ const tryPluginFallback = async (token: number, track: Track): Promise<boolean> 
 };
 
 /**
- * 插件歌词作为首选来源：开启偏好时在所有网络来源之前尝试
- * 关闭时不发起请求，插件仍按原有顺序兜底
- * @param token - 竞态 token
- * @param track - 歌曲信息
- * @returns 是否已提交有效歌词
- */
-const tryPreferredPlugin = async (token: number, track: Track): Promise<boolean> => {
-  const resolved = await resolvePreferredPluginLyric(track);
-  if (token !== currentToken) return false;
-  return resolved ? commitResolvedAndHasParsed(token, resolved) : false;
-};
-
-/**
  * 流媒体歌词加载：按来源偏好解析，失败后使用插件和内嵌歌词兜底
+ * 开启 preferPluginLyric 时与插件并发请求，先到先提交，更优格式热替换
  * @param token - 竞态 token
  * @param track - 歌曲信息
  * @param detail - 歌曲详细信息
@@ -161,9 +168,36 @@ const loadStreamingLyric = async (
   track: Track,
   detail: TrackDetail | null,
 ): Promise<void> => {
+  const preferPlugin = isPluginLyricPreferred();
+  const embeddedFallback = embeddedLyricFromDetail(detail);
+
+  if (preferPlugin) {
+    const streamingTask = (async () => {
+      const resolved = await resolveStreamingByPreference(track, () => token === currentToken);
+      if (token !== currentToken || !resolved) return;
+      commitIfBetter(token, resolved);
+    })().catch((err) => console.error("[lyricLoader] streamingTask error:", err));
+
+    const pluginTask = (async () => {
+      const plugin = await resolvePluginLyric(track);
+      if (token !== currentToken || !plugin) return;
+      commitIfBetter(token, plugin);
+    })().catch((err) => console.error("[lyricLoader] pluginTask error:", err));
+
+    await Promise.all([streamingTask, pluginTask]);
+    if (token !== currentToken) return;
+    if (useMediaStore().parsedLyric.length === 0) {
+      if (embeddedFallback) {
+        commit(token, embeddedFallback.source, { content: embeddedFallback.content });
+      } else {
+        commit(token, null, null);
+      }
+    }
+    return;
+  }
+
   const resolved = await resolveStreamingByPreference(track, () => token === currentToken);
   if (token !== currentToken) return;
-  const embeddedFallback = embeddedLyricFromDetail(detail);
   if (resolved && commitResolvedAndHasParsed(token, resolved)) return;
   if (token !== currentToken) return;
   if (await tryPluginFallback(token, track)) return;
@@ -176,10 +210,43 @@ const loadStreamingLyric = async (
 
 /**
  * 在线平台歌曲歌词加载
+ * 开启 preferPluginLyric 时与插件并发请求，先到先提交，更优格式热替换
+ * 未开启时保持内置平台优先，失败后插件兜底
  * @param token - 竞态 token
  * @param track - 歌曲信息
  */
 const loadPlatformLyric = async (token: number, track: Track): Promise<void> => {
+  const preferPlugin = isPluginLyricPreferred();
+
+  if (preferPlugin) {
+    const onlineTask = (async () => {
+      const online = await resolveOnlineByPreference(track, {
+        hasLocal: false,
+        localFormat: null,
+        onCandidate: (result) => {
+          if (token !== currentToken) return;
+          commitIfBetter(token, result);
+        },
+        shouldContinue: () => token === currentToken,
+      });
+      if (token !== currentToken || !online) return;
+      await applyOnline(token, track, online, null);
+    })().catch((err) => console.error("[lyricLoader] onlineTask error:", err));
+
+    const pluginTask = (async () => {
+      const plugin = await resolvePluginLyric(track);
+      if (token !== currentToken || !plugin) return;
+      commitIfBetter(token, plugin);
+    })().catch((err) => console.error("[lyricLoader] pluginTask error:", err));
+
+    await Promise.all([onlineTask, pluginTask]);
+    if (token !== currentToken) return;
+    if (useMediaStore().parsedLyric.length === 0) {
+      commit(token, null, null);
+    }
+    return;
+  }
+
   const online = await resolveOnlineByPreference(track, {
     hasLocal: false,
     localFormat: null,
@@ -204,7 +271,7 @@ export const beginLoad = (): number => {
  * 2. 在线歌曲：
  *    - 默认顺序下，track.platform 与候选平台一致时走 matchById
  *    - 不一致则走 matchByQuery
- * 3. 本地歌曲：本地有先立即 commit 显示；再按偏好查在线，命中热替换
+ * 3. 本地歌曲：本地有先立即 commit 显示；再按偏好查在线/插件，命中热替换
  * 4. 本地 + 在线都无：commit null 收尾 loading
  *
  * @param detail - 歌曲详细信息
@@ -227,9 +294,6 @@ export const loadForTrack = async (detail: TrackDetail | null): Promise<void> =>
     // 本地 TTML 歌词库最高优先
     if (await tryLocalRepo(token, track)) return;
     if (token !== currentToken) return;
-    // 插件首选：仅在开启偏好时先于所有网络来源
-    if (await tryPreferredPlugin(token, track)) return;
-    if (token !== currentToken) return;
     // 在线歌曲（任一在线平台）
     if (isPlatform(track.source)) {
       await loadPlatformLyric(token, track);
@@ -248,6 +312,39 @@ export const loadForTrack = async (detail: TrackDetail | null): Promise<void> =>
     // 本地文件存在但解析后空
     const hasUsableLocal = !!local && media.parsedLyric.length > 0;
     const localFormat = local?.source.format ?? null;
+
+    const preferPlugin = isPluginLyricPreferred();
+    if (preferPlugin) {
+      const onlineTask = (async () => {
+        const online = await resolveOnlineByPreference(track, {
+          hasLocal: hasUsableLocal,
+          localFormat,
+          onCandidate: (result) => {
+            if (token !== currentToken) return;
+            commitIfBetter(token, result);
+          },
+          shouldContinue: () => token === currentToken,
+        });
+        if (token !== currentToken) return;
+        // id 回查本地 TTML 库
+        if (online && (await tryLocalRepo(token, track))) return;
+        if (online) await applyOnline(token, track, online, local);
+      })().catch((err) => console.error("[lyricLoader] onlineTask error:", err));
+
+      const pluginTask = (async () => {
+        const plugin = await resolvePluginLyric(track);
+        if (token !== currentToken || !plugin) return;
+        commitIfBetter(token, plugin);
+      })().catch((err) => console.error("[lyricLoader] pluginTask error:", err));
+
+      await Promise.all([onlineTask, pluginTask]);
+      if (token !== currentToken) return;
+      if (!hasUsableLocal && media.parsedLyric.length === 0) {
+        commit(token, null, null);
+      }
+      return;
+    }
+
     // 按偏好获取歌词
     const online = await resolveOnlineByPreference(track, {
       hasLocal: hasUsableLocal,
@@ -279,9 +376,6 @@ const refreshPreference = async (): Promise<void> => {
   // 本地 TTML 歌词库最高优先
   if (await tryLocalRepo(token, track)) return;
   if (token !== currentToken) return;
-  // 插件首选
-  if (await tryPreferredPlugin(token, track)) return;
-  if (token !== currentToken) return;
   if (track.source === "streaming") {
     await loadStreamingLyric(token, track, media.detail);
     return;
@@ -297,6 +391,39 @@ const refreshPreference = async (): Promise<void> => {
   if (token !== currentToken) return;
   const localFormat = local?.source.format ?? null;
   const showingOnline = media.activeLyric?.source === "online";
+  const preferPlugin = isPluginLyricPreferred();
+
+  if (preferPlugin) {
+    const onlineTask = (async () => {
+      const online = await resolveOnlineByPreference(track, {
+        hasLocal: !!local,
+        localFormat,
+        onCandidate: (result) => {
+          if (token !== currentToken) return;
+          commitIfBetter(token, result);
+        },
+        shouldContinue: () => token === currentToken,
+      });
+      if (token !== currentToken || !online) return;
+      await applyOnline(token, track, online, local);
+    })().catch((err) => console.error("[lyricLoader] refresh onlineTask error:", err));
+
+    const pluginTask = (async () => {
+      const plugin = await resolvePluginLyric(track);
+      if (token !== currentToken || !plugin) return;
+      commitIfBetter(token, plugin);
+    })().catch((err) => console.error("[lyricLoader] refresh pluginTask error:", err));
+
+    await Promise.all([onlineTask, pluginTask]);
+    if (token !== currentToken) return;
+    if (media.parsedLyric.length > 0) return;
+    // 目标是本地
+    if (!showingOnline) return;
+    if (local) commitLocal(token, local);
+    else commit(token, null, null);
+    return;
+  }
+
   /** 按偏好获取歌词 */
   const online = await resolveOnlineByPreference(track, {
     hasLocal: !!local,

--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -82,21 +82,6 @@ const commitResolvedAndHasParsed = (token: number, resolved: ResolvedLyric): boo
   commitAndHasParsed(token, resolved.source, resolved.input);
 
 /**
- * 尝试提交已解析歌词；若当前已展示更优或同级格式则忽略
- * @param token - 竞态 token
- * @param resolved - 待提交的歌词候选
- * @returns 是否成功提交且有有效行
- */
-const commitIfBetter = (token: number, resolved: ResolvedLyric): boolean => {
-  if (token !== currentToken) return false;
-  const currentFormat = useMediaStore().activeLyric?.format ?? null;
-  if (!currentFormat || isBetterFormat(resolved.source.format, currentFormat)) {
-    return commitResolvedAndHasParsed(token, resolved);
-  }
-  return false;
-};
-
-/**
  * 提交在线歌词；解析后为空时优先回退本地，本地也无再按需 TTML 升级
  */
 const applyOnline = async (
@@ -107,20 +92,17 @@ const applyOnline = async (
 ): Promise<void> => {
   const media = useMediaStore();
   const current = media.activeLyric;
-  const currentFormat = current?.format ?? null;
   // 跳过同源同格式
   const alreadyCommitted =
     current?.source === "online" &&
     current.platform === online.source.platform &&
     current.format === online.source.format;
   if (!alreadyCommitted) {
-    if (!currentFormat || isBetterFormat(online.source.format, currentFormat)) {
-      if (!commitAndHasParsed(token, online.source, online.input) && fallbackLocal) {
-        commitLocal(token, fallbackLocal);
-        return;
-      }
-      if (token !== currentToken) return;
+    if (!commitAndHasParsed(token, online.source, online.input) && fallbackLocal) {
+      commitLocal(token, fallbackLocal);
+      return;
     }
+    if (token !== currentToken) return;
   } else if (media.parsedLyric.length === 0 && fallbackLocal) {
     commitLocal(token, fallbackLocal);
     return;
@@ -128,7 +110,7 @@ const applyOnline = async (
   const ttml = await resolveTTMLOverlay(track, online);
   if (token !== currentToken) return;
   if (ttml) {
-    commitIfBetter(token, ttml);
+    commit(token, ttml.source, ttml.input);
   }
 };
 
@@ -151,111 +133,80 @@ const tryLocalRepo = async (token: number, track: Track): Promise<boolean> => {
  * @returns 是否已提交有效歌词
  */
 const tryPluginFallback = async (token: number, track: Track): Promise<boolean> => {
+  // 插件优选时不处理
+  if (isPluginLyricPreferred()) return false;
   const resolved = await resolvePluginLyric(track);
   if (token !== currentToken) return false;
   return resolved ? commitResolvedAndHasParsed(token, resolved) : false;
 };
 
 /**
- * 流媒体歌词加载：按来源偏好解析，失败后使用插件和内嵌歌词兜底
- * 开启 preferPluginLyric 时与插件并发请求，先到先提交，更优格式热替换
+ * 插件优先加载
+ * 插件请求与正常流程并发发出，正常流程先展示，插件返回更优格式时替换
  * @param token - 竞态 token
  * @param track - 歌曲信息
- * @param detail - 歌曲详细信息
+ * @param run - 正常加载流程
  */
-const loadStreamingLyric = async (
+const withPluginPrefer = async (
   token: number,
   track: Track,
-  detail: TrackDetail | null,
+  run: () => Promise<void>,
 ): Promise<void> => {
-  const preferPlugin = isPluginLyricPreferred();
-  const embeddedFallback = embeddedLyricFromDetail(detail);
-
-  if (preferPlugin) {
-    const streamingTask = (async () => {
-      const resolved = await resolveStreamingByPreference(track, () => token === currentToken);
-      if (token !== currentToken || !resolved) return;
-      commitIfBetter(token, resolved);
-    })().catch((err) => console.error("[lyricLoader] streamingTask error:", err));
-
-    const pluginTask = (async () => {
-      const plugin = await resolvePluginLyric(track);
-      if (token !== currentToken || !plugin) return;
-      commitIfBetter(token, plugin);
-    })().catch((err) => console.error("[lyricLoader] pluginTask error:", err));
-
-    await Promise.all([streamingTask, pluginTask]);
-    if (token !== currentToken) return;
-    if (useMediaStore().parsedLyric.length === 0) {
-      if (embeddedFallback) {
-        commit(token, embeddedFallback.source, { content: embeddedFallback.content });
-      } else {
-        commit(token, null, null);
-      }
-    }
+  if (!isPluginLyricPreferred()) {
+    await run();
     return;
   }
-
-  const resolved = await resolveStreamingByPreference(track, () => token === currentToken);
-  if (token !== currentToken) return;
-  if (resolved && commitResolvedAndHasParsed(token, resolved)) return;
-  if (token !== currentToken) return;
-  if (await tryPluginFallback(token, track)) return;
-  if (embeddedFallback) {
-    commit(token, embeddedFallback.source, { content: embeddedFallback.content });
-  } else {
-    commit(token, null, null);
+  const pluginTask = resolvePluginLyric(track);
+  await run();
+  const plugin = await pluginTask;
+  if (!plugin || token !== currentToken) return;
+  const currentFormat = useMediaStore().activeLyric?.format ?? null;
+  if (isBetterFormat(plugin.source.format, currentFormat)) {
+    commitResolvedAndHasParsed(token, plugin);
   }
 };
 
 /**
+ * 流媒体歌词加载：按来源偏好解析，失败后使用插件和内嵌歌词兜底
+ * @param token - 竞态 token
+ * @param track - 歌曲信息
+ * @param detail - 歌曲详细信息
+ */
+const loadStreamingLyric = (
+  token: number,
+  track: Track,
+  detail: TrackDetail | null,
+): Promise<void> =>
+  withPluginPrefer(token, track, async () => {
+    const resolved = await resolveStreamingByPreference(track, () => token === currentToken);
+    if (token !== currentToken) return;
+    const embeddedFallback = embeddedLyricFromDetail(detail);
+    if (resolved && commitResolvedAndHasParsed(token, resolved)) return;
+    if (token !== currentToken) return;
+    if (await tryPluginFallback(token, track)) return;
+    if (embeddedFallback) {
+      commit(token, embeddedFallback.source, { content: embeddedFallback.content });
+    } else {
+      commit(token, null, null);
+    }
+  });
+
+/**
  * 在线平台歌曲歌词加载
- * 开启 preferPluginLyric 时与插件并发请求，先到先提交，更优格式热替换
- * 未开启时保持内置平台优先，失败后插件兜底
  * @param token - 竞态 token
  * @param track - 歌曲信息
  */
-const loadPlatformLyric = async (token: number, track: Track): Promise<void> => {
-  const preferPlugin = isPluginLyricPreferred();
-
-  if (preferPlugin) {
-    const onlineTask = (async () => {
-      const online = await resolveOnlineByPreference(track, {
-        hasLocal: false,
-        localFormat: null,
-        onCandidate: (result) => {
-          if (token !== currentToken) return;
-          commitIfBetter(token, result);
-        },
-        shouldContinue: () => token === currentToken,
-      });
-      if (token !== currentToken || !online) return;
-      await applyOnline(token, track, online, null);
-    })().catch((err) => console.error("[lyricLoader] onlineTask error:", err));
-
-    const pluginTask = (async () => {
-      const plugin = await resolvePluginLyric(track);
-      if (token !== currentToken || !plugin) return;
-      commitIfBetter(token, plugin);
-    })().catch((err) => console.error("[lyricLoader] pluginTask error:", err));
-
-    await Promise.all([onlineTask, pluginTask]);
+const loadPlatformLyric = (token: number, track: Track): Promise<void> =>
+  withPluginPrefer(token, track, async () => {
+    const online = await resolveOnlineByPreference(track, {
+      hasLocal: false,
+      localFormat: null,
+      shouldContinue: () => token === currentToken,
+    });
     if (token !== currentToken) return;
-    if (useMediaStore().parsedLyric.length === 0) {
-      commit(token, null, null);
-    }
-    return;
-  }
-
-  const online = await resolveOnlineByPreference(track, {
-    hasLocal: false,
-    localFormat: null,
-    shouldContinue: () => token === currentToken,
+    if (online) await applyOnline(token, track, online, null);
+    else if (!(await tryPluginFallback(token, track))) commit(token, null, null);
   });
-  if (token !== currentToken) return;
-  if (online) await applyOnline(token, track, online, null);
-  else if (!(await tryPluginFallback(token, track))) commit(token, null, null);
-};
 
 /** 开启新一轮加载周期 */
 export const beginLoad = (): number => {
@@ -271,7 +222,7 @@ export const beginLoad = (): number => {
  * 2. 在线歌曲：
  *    - 默认顺序下，track.platform 与候选平台一致时走 matchById
  *    - 不一致则走 matchByQuery
- * 3. 本地歌曲：本地有先立即 commit 显示；再按偏好查在线/插件，命中热替换
+ * 3. 本地歌曲：本地有先立即 commit 显示；再按偏好查在线，命中热替换
  * 4. 本地 + 在线都无：commit null 收尾 loading
  *
  * @param detail - 歌曲详细信息
@@ -313,53 +264,23 @@ export const loadForTrack = async (detail: TrackDetail | null): Promise<void> =>
     const hasUsableLocal = !!local && media.parsedLyric.length > 0;
     const localFormat = local?.source.format ?? null;
 
-    const preferPlugin = isPluginLyricPreferred();
-    if (preferPlugin) {
-      const onlineTask = (async () => {
-        const online = await resolveOnlineByPreference(track, {
-          hasLocal: hasUsableLocal,
-          localFormat,
-          onCandidate: (result) => {
-            if (token !== currentToken) return;
-            commitIfBetter(token, result);
-          },
-          shouldContinue: () => token === currentToken,
-        });
-        if (token !== currentToken) return;
-        // id 回查本地 TTML 库
-        if (online && (await tryLocalRepo(token, track))) return;
-        if (online) await applyOnline(token, track, online, local);
-      })().catch((err) => console.error("[lyricLoader] onlineTask error:", err));
-
-      const pluginTask = (async () => {
-        const plugin = await resolvePluginLyric(track);
-        if (token !== currentToken || !plugin) return;
-        commitIfBetter(token, plugin);
-      })().catch((err) => console.error("[lyricLoader] pluginTask error:", err));
-
-      await Promise.all([onlineTask, pluginTask]);
+    await withPluginPrefer(token, track, async () => {
+      // 按偏好获取歌词
+      const online = await resolveOnlineByPreference(track, {
+        hasLocal: hasUsableLocal,
+        localFormat,
+        onCandidate: (result) => commit(token, result.source, result.input),
+        shouldContinue: () => token === currentToken,
+      });
       if (token !== currentToken) return;
-      if (!hasUsableLocal && media.parsedLyric.length === 0) {
+      // id 回查本地 TTML 库
+      if (online && (await tryLocalRepo(token, track))) return;
+      if (online) {
+        await applyOnline(token, track, online, local);
+      } else if (!hasUsableLocal && !(await tryPluginFallback(token, track))) {
         commit(token, null, null);
       }
-      return;
-    }
-
-    // 按偏好获取歌词
-    const online = await resolveOnlineByPreference(track, {
-      hasLocal: hasUsableLocal,
-      localFormat,
-      onCandidate: (result) => commit(token, result.source, result.input),
-      shouldContinue: () => token === currentToken,
     });
-    if (token !== currentToken) return;
-    // id 回查本地 TTML 库
-    if (online && (await tryLocalRepo(token, track))) return;
-    if (online) {
-      await applyOnline(token, track, online, local);
-    } else if (!hasUsableLocal && !(await tryPluginFallback(token, track))) {
-      commit(token, null, null);
-    }
   } catch (err) {
     console.error("[lyricLoader] loadForTrack failed:", err);
     commit(token, null, null);
@@ -391,55 +312,25 @@ const refreshPreference = async (): Promise<void> => {
   if (token !== currentToken) return;
   const localFormat = local?.source.format ?? null;
   const showingOnline = media.activeLyric?.source === "online";
-  const preferPlugin = isPluginLyricPreferred();
 
-  if (preferPlugin) {
-    const onlineTask = (async () => {
-      const online = await resolveOnlineByPreference(track, {
-        hasLocal: !!local,
-        localFormat,
-        onCandidate: (result) => {
-          if (token !== currentToken) return;
-          commitIfBetter(token, result);
-        },
-        shouldContinue: () => token === currentToken,
-      });
-      if (token !== currentToken || !online) return;
-      await applyOnline(token, track, online, local);
-    })().catch((err) => console.error("[lyricLoader] refresh onlineTask error:", err));
-
-    const pluginTask = (async () => {
-      const plugin = await resolvePluginLyric(track);
-      if (token !== currentToken || !plugin) return;
-      commitIfBetter(token, plugin);
-    })().catch((err) => console.error("[lyricLoader] refresh pluginTask error:", err));
-
-    await Promise.all([onlineTask, pluginTask]);
+  await withPluginPrefer(token, track, async () => {
+    /** 按偏好获取歌词 */
+    const online = await resolveOnlineByPreference(track, {
+      hasLocal: !!local,
+      localFormat,
+      onCandidate: (result) => commit(token, result.source, result.input),
+      shouldContinue: () => token === currentToken,
+    });
     if (token !== currentToken) return;
-    if (media.parsedLyric.length > 0) return;
+    if (online) {
+      await applyOnline(token, track, online, local);
+      return;
+    }
     // 目标是本地
     if (!showingOnline) return;
     if (local) commitLocal(token, local);
     else commit(token, null, null);
-    return;
-  }
-
-  /** 按偏好获取歌词 */
-  const online = await resolveOnlineByPreference(track, {
-    hasLocal: !!local,
-    localFormat,
-    onCandidate: (result) => commit(token, result.source, result.input),
-    shouldContinue: () => token === currentToken,
   });
-  if (token !== currentToken) return;
-  if (online) {
-    await applyOnline(token, track, online, local);
-    return;
-  }
-  // 目标是本地
-  if (!showingOnline) return;
-  if (local) commitLocal(token, local);
-  else commit(token, null, null);
 };
 
 /** 监听歌词偏好变化 */

--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -14,6 +14,7 @@ import {
   resolveLocalRepoLyric,
   resolveOnlineByPreference,
   resolvePluginLyric,
+  resolvePreferredPluginLyric,
   resolveStreamingByPreference,
   resolveTTMLOverlay,
   type LocalLyric,
@@ -137,6 +138,19 @@ const tryPluginFallback = async (token: number, track: Track): Promise<boolean> 
 };
 
 /**
+ * 插件歌词作为首选来源：开启偏好时在所有网络来源之前尝试
+ * 关闭时不发起请求，插件仍按原有顺序兜底
+ * @param token - 竞态 token
+ * @param track - 歌曲信息
+ * @returns 是否已提交有效歌词
+ */
+const tryPreferredPlugin = async (token: number, track: Track): Promise<boolean> => {
+  const resolved = await resolvePreferredPluginLyric(track);
+  if (token !== currentToken) return false;
+  return resolved ? commitResolvedAndHasParsed(token, resolved) : false;
+};
+
+/**
  * 流媒体歌词加载：按来源偏好解析，失败后使用插件和内嵌歌词兜底
  * @param token - 竞态 token
  * @param track - 歌曲信息
@@ -213,6 +227,9 @@ export const loadForTrack = async (detail: TrackDetail | null): Promise<void> =>
     // 本地 TTML 歌词库最高优先
     if (await tryLocalRepo(token, track)) return;
     if (token !== currentToken) return;
+    // 插件首选：仅在开启偏好时先于所有网络来源
+    if (await tryPreferredPlugin(token, track)) return;
+    if (token !== currentToken) return;
     // 在线歌曲（任一在线平台）
     if (isPlatform(track.source)) {
       await loadPlatformLyric(token, track);
@@ -262,6 +279,9 @@ const refreshPreference = async (): Promise<void> => {
   // 本地 TTML 歌词库最高优先
   if (await tryLocalRepo(token, track)) return;
   if (token !== currentToken) return;
+  // 插件首选
+  if (await tryPreferredPlugin(token, track)) return;
+  if (token !== currentToken) return;
   if (track.source === "streaming") {
     await loadStreamingLyric(token, track, media.detail);
     return;
@@ -302,6 +322,7 @@ export const watchLyricPreference = (): void => {
     () => [
       settings.lyric.lyricSourcePreference,
       settings.lyric.smartPreferOnline,
+      settings.lyric.preferPluginLyric,
       settings.lyric.detectBackgroundLyrics,
       settings.system.lyric.enableOnlineTTMLLyric,
       settings.system.localLyric.enableLocalTTMLOverride,

--- a/src/services/lyric/preload.ts
+++ b/src/services/lyric/preload.ts
@@ -37,6 +37,7 @@ const buildContextKey = (): string => {
     settings.lyric.lyricSourceOrder,
     settings.lyric.lyricFormatOrder,
     settings.lyric.smartPreferOnline,
+    settings.lyric.preferPluginLyric,
     settings.system.lyric.enableOnlineTTMLLyric,
     settings.system.localLyric.enableLocalTTMLOverride,
     settings.system.localLyric.repoDir,

--- a/src/services/lyric/resolve.ts
+++ b/src/services/lyric/resolve.ts
@@ -295,6 +295,21 @@ export const resolvePluginLyric = async (track: Track): Promise<ResolvedLyric | 
   return null;
 };
 
+/** 插件歌词是否作为首选来源（本地 TTML 仓库仍最高） */
+export const isPluginLyricPreferred = (): boolean =>
+  useSettingsStore().lyric.preferPluginLyric === true;
+
+/**
+ * 插件歌词作为首选时的前置尝试
+ * 关闭该偏好时不发起任何插件请求，保持原有兜底语义
+ * @param track - 歌曲信息
+ * @returns 命中的插件歌词，未开启或未命中返回 null
+ */
+export const resolvePreferredPluginLyric = async (track: Track): Promise<ResolvedLyric | null> => {
+  if (!isPluginLyricPreferred()) return null;
+  return resolvePluginLyric(track);
+};
+
 /**
  * 为下一首歌曲解析最终歌词结果
  * 本地歌曲依赖实际加载后的 TrackDetail，不在此处提前解析
@@ -310,6 +325,10 @@ export const resolveLyricForPreload = async (
   const localRepo = await resolveLocalRepoLyric(track);
   if (!shouldContinue()) return null;
   if (localRepo) return localRepo;
+
+  const preferredPlugin = await resolvePreferredPluginLyric(track);
+  if (!shouldContinue()) return null;
+  if (preferredPlugin) return preferredPlugin;
 
   if (track.source === "streaming") {
     const streaming = await resolveStreamingByPreference(track, shouldContinue);

--- a/src/services/lyric/resolve.ts
+++ b/src/services/lyric/resolve.ts
@@ -94,14 +94,30 @@ const platformCanUpgrade = (
   return false;
 };
 
-/** 判断在线结果是否优于本地歌词 */
-const isOnlineResultUpgrade = (result: OnlineResult, localFormat: LyricFormat): boolean => {
-  const formatOrder = useSettingsStore().lyric.lyricFormatOrder ?? DEFAULT_LYRIC_FORMAT_ORDER;
-  const localIdx = formatOrder.indexOf(localFormat);
-  if (localIdx === -1) return true;
-  const mainIdx = formatOrder.indexOf(result.source.format);
-  return mainIdx !== -1 && mainIdx < localIdx;
+/**
+ * 判断 candidateFormat 是否比 currentFormat 更优（优先级更高）
+ * @param candidateFormat - 候选格式
+ * @param currentFormat - 当前格式（为 null 时直接判定为更优）
+ * @param formatOrder - 格式优先级列表，省略则从 store 取
+ */
+export const isBetterFormat = (
+  candidateFormat: LyricFormat,
+  currentFormat: LyricFormat | null,
+  formatOrder?: readonly LyricFormat[],
+): boolean => {
+  if (!currentFormat) return true;
+  const order =
+    formatOrder ?? useSettingsStore().lyric.lyricFormatOrder ?? DEFAULT_LYRIC_FORMAT_ORDER;
+  const currIdx = order.indexOf(currentFormat);
+  const candIdx = order.indexOf(candidateFormat);
+  const currRank = currIdx === -1 ? order.length : currIdx;
+  const candRank = candIdx === -1 ? order.length : candIdx;
+  return candRank < currRank;
 };
+
+/** 判断在线结果是否优于本地歌词 */
+const isOnlineResultUpgrade = (result: OnlineResult, localFormat: LyricFormat): boolean =>
+  isBetterFormat(result.source.format, localFormat);
 
 interface OnlinePreferenceOptions {
   hasLocal: boolean;
@@ -273,47 +289,41 @@ export const resolveLocalRepoLyric = async (track: Track): Promise<ResolvedLyric
  * @returns 首个有效插件歌词，不存在则返回 null
  */
 export const resolvePluginLyric = async (track: Track): Promise<ResolvedLyric | null> => {
-  const plugins = usePluginsStore();
-  for (const info of plugins.list) {
-    if (!info.enabled || info.status.state !== "ready") continue;
-    for (const [source, cap] of Object.entries(info.status.sources)) {
-      if (!cap.actions.includes("musicLyric")) continue;
-      const resp = await window.api.plugins.matchLyric({
-        pluginId: info.manifest.id,
-        source,
-        track,
-      });
-      if (!resp.ok || !resp.data) continue;
-      const content = resp.data.awlyric ?? resp.data.lyric;
-      if (!content?.trim()) continue;
-      return {
-        source: { source: "online", format: detectFormat(content) },
-        input: { content, translation: resp.data.tlyric, romaji: resp.data.rlyric },
-      };
+  try {
+    const plugins = usePluginsStore();
+    for (const info of plugins.list) {
+      if (!info.enabled || info.status.state !== "ready") continue;
+      for (const [source, cap] of Object.entries(info.status.sources)) {
+        if (!cap.actions.includes("musicLyric")) continue;
+        const resp = await window.api.plugins.matchLyric({
+          pluginId: info.manifest.id,
+          source,
+          track,
+        });
+        if (!resp.ok || !resp.data) continue;
+        const content = resp.data.awlyric ?? resp.data.lyric;
+        if (!content?.trim()) continue;
+        return {
+          source: { source: "online", format: detectFormat(content) },
+          input: { content, translation: resp.data.tlyric, romaji: resp.data.rlyric },
+        };
+      }
     }
+  } catch (err) {
+    console.error("[lyricResolve] resolvePluginLyric failed:", err);
   }
   return null;
 };
 
-/** 插件歌词是否作为首选来源（本地 TTML 仓库仍最高） */
+/** 插件歌词是否作为首选来源（开启后与内置来源并发请求并择优） */
 export const isPluginLyricPreferred = (): boolean =>
   useSettingsStore().lyric.preferPluginLyric === true;
-
-/**
- * 插件歌词作为首选时的前置尝试
- * 关闭该偏好时不发起任何插件请求，保持原有兜底语义
- * @param track - 歌曲信息
- * @returns 命中的插件歌词，未开启或未命中返回 null
- */
-export const resolvePreferredPluginLyric = async (track: Track): Promise<ResolvedLyric | null> => {
-  if (!isPluginLyricPreferred()) return null;
-  return resolvePluginLyric(track);
-};
 
 /**
  * 为下一首歌曲解析最终歌词结果
  * 本地歌曲依赖实际加载后的 TrackDetail，不在此处提前解析
  * @param track - 候选歌曲
+ * @param shouldContinue - 竞态检查
  * @returns 最终歌词，不存在或不支持预载则返回 null
  */
 export const resolveLyricForPreload = async (
@@ -326,16 +336,47 @@ export const resolveLyricForPreload = async (
   if (!shouldContinue()) return null;
   if (localRepo) return localRepo;
 
-  const preferredPlugin = await resolvePreferredPluginLyric(track);
-  if (!shouldContinue()) return null;
-  if (preferredPlugin) return preferredPlugin;
+  const preferPlugin = isPluginLyricPreferred();
 
   if (track.source === "streaming") {
+    if (preferPlugin) {
+      const [streaming, plugin] = await Promise.all([
+        resolveStreamingByPreference(track, shouldContinue),
+        resolvePluginLyric(track),
+      ]);
+      if (!shouldContinue()) return null;
+      if (plugin && isBetterFormat(plugin.source.format, streaming?.source.format ?? null)) {
+        return plugin;
+      }
+      return streaming ?? plugin ?? null;
+    }
     const streaming = await resolveStreamingByPreference(track, shouldContinue);
     if (!shouldContinue()) return null;
     if (streaming) return streaming;
     const plugin = await resolvePluginLyric(track);
     return shouldContinue() ? plugin : null;
+  }
+
+  if (preferPlugin) {
+    const [onlineLyric, plugin] = await Promise.all([
+      (async () => {
+        const online = await resolveOnlineByPreference(track, {
+          hasLocal: false,
+          localFormat: null,
+          shouldContinue,
+        });
+        if (!shouldContinue() || !online) return null;
+        const ttml = await resolveTTMLOverlay(track, online);
+        if (!shouldContinue()) return null;
+        return ttml ?? { source: online.source, input: online.input };
+      })(),
+      resolvePluginLyric(track),
+    ]);
+    if (!shouldContinue()) return null;
+    if (plugin && isBetterFormat(plugin.source.format, onlineLyric?.source.format ?? null)) {
+      return plugin;
+    }
+    return onlineLyric ?? plugin ?? null;
   }
 
   const online = await resolveOnlineByPreference(track, {

--- a/src/services/lyric/resolve.ts
+++ b/src/services/lyric/resolve.ts
@@ -98,16 +98,13 @@ const platformCanUpgrade = (
  * 判断 candidateFormat 是否比 currentFormat 更优（优先级更高）
  * @param candidateFormat - 候选格式
  * @param currentFormat - 当前格式（为 null 时直接判定为更优）
- * @param formatOrder - 格式优先级列表，省略则从 store 取
  */
 export const isBetterFormat = (
   candidateFormat: LyricFormat,
   currentFormat: LyricFormat | null,
-  formatOrder?: readonly LyricFormat[],
 ): boolean => {
   if (!currentFormat) return true;
-  const order =
-    formatOrder ?? useSettingsStore().lyric.lyricFormatOrder ?? DEFAULT_LYRIC_FORMAT_ORDER;
+  const order = useSettingsStore().lyric.lyricFormatOrder ?? DEFAULT_LYRIC_FORMAT_ORDER;
   const currIdx = order.indexOf(currentFormat);
   const candIdx = order.indexOf(candidateFormat);
   const currRank = currIdx === -1 ? order.length : currIdx;
@@ -289,33 +286,29 @@ export const resolveLocalRepoLyric = async (track: Track): Promise<ResolvedLyric
  * @returns 首个有效插件歌词，不存在则返回 null
  */
 export const resolvePluginLyric = async (track: Track): Promise<ResolvedLyric | null> => {
-  try {
-    const plugins = usePluginsStore();
-    for (const info of plugins.list) {
-      if (!info.enabled || info.status.state !== "ready") continue;
-      for (const [source, cap] of Object.entries(info.status.sources)) {
-        if (!cap.actions.includes("musicLyric")) continue;
-        const resp = await window.api.plugins.matchLyric({
-          pluginId: info.manifest.id,
-          source,
-          track,
-        });
-        if (!resp.ok || !resp.data) continue;
-        const content = resp.data.awlyric ?? resp.data.lyric;
-        if (!content?.trim()) continue;
-        return {
-          source: { source: "online", format: detectFormat(content) },
-          input: { content, translation: resp.data.tlyric, romaji: resp.data.rlyric },
-        };
-      }
+  const plugins = usePluginsStore();
+  for (const info of plugins.list) {
+    if (!info.enabled || info.status.state !== "ready") continue;
+    for (const [source, cap] of Object.entries(info.status.sources)) {
+      if (!cap.actions.includes("musicLyric")) continue;
+      const resp = await window.api.plugins.matchLyric({
+        pluginId: info.manifest.id,
+        source,
+        track,
+      });
+      if (!resp.ok || !resp.data) continue;
+      const content = resp.data.awlyric ?? resp.data.lyric;
+      if (!content?.trim()) continue;
+      return {
+        source: { source: "online", format: detectFormat(content) },
+        input: { content, translation: resp.data.tlyric, romaji: resp.data.rlyric },
+      };
     }
-  } catch (err) {
-    console.error("[lyricResolve] resolvePluginLyric failed:", err);
   }
   return null;
 };
 
-/** 插件歌词是否作为首选来源（开启后与内置来源并发请求并择优） */
+/** 插件歌词是否优先于内置来源 */
 export const isPluginLyricPreferred = (): boolean =>
   useSettingsStore().lyric.preferPluginLyric === true;
 
@@ -336,47 +329,23 @@ export const resolveLyricForPreload = async (
   if (!shouldContinue()) return null;
   if (localRepo) return localRepo;
 
-  const preferPlugin = isPluginLyricPreferred();
+  // 插件优选：请求先行发出，与下方正常解析并发
+  const pluginTask = isPluginLyricPreferred() ? resolvePluginLyric(track) : null;
 
   if (track.source === "streaming") {
-    if (preferPlugin) {
-      const [streaming, plugin] = await Promise.all([
-        resolveStreamingByPreference(track, shouldContinue),
-        resolvePluginLyric(track),
-      ]);
+    const streaming = await resolveStreamingByPreference(track, shouldContinue);
+    if (!shouldContinue()) return null;
+    if (pluginTask) {
+      const plugin = await pluginTask;
       if (!shouldContinue()) return null;
       if (plugin && isBetterFormat(plugin.source.format, streaming?.source.format ?? null)) {
         return plugin;
       }
       return streaming ?? plugin ?? null;
     }
-    const streaming = await resolveStreamingByPreference(track, shouldContinue);
-    if (!shouldContinue()) return null;
     if (streaming) return streaming;
     const plugin = await resolvePluginLyric(track);
     return shouldContinue() ? plugin : null;
-  }
-
-  if (preferPlugin) {
-    const [onlineLyric, plugin] = await Promise.all([
-      (async () => {
-        const online = await resolveOnlineByPreference(track, {
-          hasLocal: false,
-          localFormat: null,
-          shouldContinue,
-        });
-        if (!shouldContinue() || !online) return null;
-        const ttml = await resolveTTMLOverlay(track, online);
-        if (!shouldContinue()) return null;
-        return ttml ?? { source: online.source, input: online.input };
-      })(),
-      resolvePluginLyric(track),
-    ]);
-    if (!shouldContinue()) return null;
-    if (plugin && isBetterFormat(plugin.source.format, onlineLyric?.source.format ?? null)) {
-      return plugin;
-    }
-    return onlineLyric ?? plugin ?? null;
   }
 
   const online = await resolveOnlineByPreference(track, {
@@ -385,11 +354,21 @@ export const resolveLyricForPreload = async (
     shouldContinue,
   });
   if (!shouldContinue()) return null;
+  let normal: ResolvedLyric | null = null;
   if (online) {
     const ttml = await resolveTTMLOverlay(track, online);
     if (!shouldContinue()) return null;
-    return ttml ?? { source: online.source, input: online.input };
+    normal = ttml ?? { source: online.source, input: online.input };
   }
+  if (pluginTask) {
+    const plugin = await pluginTask;
+    if (!shouldContinue()) return null;
+    if (plugin && isBetterFormat(plugin.source.format, normal?.source.format ?? null)) {
+      return plugin;
+    }
+    return normal ?? plugin ?? null;
+  }
+  if (normal) return normal;
 
   const plugin = await resolvePluginLyric(track);
   return shouldContinue() ? plugin : null;

--- a/src/services/nextTrackPreloader.ts
+++ b/src/services/nextTrackPreloader.ts
@@ -226,6 +226,7 @@ export const installNextTrackPreloadWatchers = (): void => {
       settings.lyric.lyricSourceOrder.join(","),
       settings.lyric.lyricFormatOrder.join(","),
       settings.lyric.smartPreferOnline,
+      settings.lyric.preferPluginLyric,
       settings.system.lyric.enableOnlineTTMLLyric,
       settings.system.localLyric.enableLocalTTMLOverride,
       settings.system.localLyric.repoDir,

--- a/src/settings/categories/lyric.ts
+++ b/src/settings/categories/lyric.ts
@@ -45,6 +45,12 @@ const lyricCategory: SettingCategory = {
           ],
         },
         {
+          key: "preferPluginLyric",
+          type: "switch",
+          binding: { store: "settings", path: "lyric.preferPluginLyric" },
+          defaultValue: false,
+        },
+        {
           key: "lyricSourceOrder",
           type: "custom",
           component: LyricSourceOrderConfig,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -92,6 +92,7 @@ export const useSettingsStore = defineStore(
       lyricSourceOrder: [...DEFAULT_LYRIC_SOURCE_ORDER],
       lyricFormatOrder: [...DEFAULT_LYRIC_FORMAT_ORDER],
       smartPreferOnline: false,
+      preferPluginLyric: false,
       detectBackgroundLyrics: true,
       cjkTransform: "none",
       adaptiveFontSize: true,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -73,7 +73,7 @@ export interface LyricSettings {
   lyricFormatOrder: LyricFormatOrder;
   /** 智能选择是否优先在线 */
   smartPreferOnline: boolean;
-  /** 插件歌词优先于内置来源（仅次于本地 TTML 歌词库） */
+  /** 优先使用插件歌词（并发请求，更优格式自动热替换） */
   preferPluginLyric: boolean;
   /** 自动识别背景歌词 */
   detectBackgroundLyrics: boolean;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -73,6 +73,8 @@ export interface LyricSettings {
   lyricFormatOrder: LyricFormatOrder;
   /** 智能选择是否优先在线 */
   smartPreferOnline: boolean;
+  /** 插件歌词优先于内置来源（仅次于本地 TTML 歌词库） */
+  preferPluginLyric: boolean;
   /** 自动识别背景歌词 */
   detectBackgroundLyrics: boolean;
   /** 中文繁简转换模式（基于 OpenCC） */


### PR DESCRIPTION
> 内容由 Gemini 3.6 Flash 生成
## 改动类型

- [x] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

1. **支持音源类插件图形化配置（Fix）**：修复 `PluginList.vue` 中配置弹窗原本限定仅在 `controlPlugins` 中检索 Schema 的问题，使其扩展为在全量已安装插件中检索，确保包含音源类在内的所有插件均可渲染图形化配置项。
2. **新增「优先使用插件歌词」偏好项（Feat）**：在系统设置「设置 → 歌词」中新增 `preferPluginLyric` 开关，打通 `loader` / `resolve` / `download` 歌词服务层，开启时插件歌词优先于内置在线平台执行，关闭时作为兜底。

## 测试情况

1. 在 Windows 11 环境运行 `pnpm build:win` 打包完整安装包并验证。
2. 验证插件列表与配置界面：音源类插件点【配置】后能正常弹窗并渲染 `text` / `select` 等类型控件。
3. 验证歌词偏好：在设置中开启「优先使用插件歌词」后切歌，能够正确触发前置插件歌词检索流程。

## 截图 / 录屏

<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/e2ea4ff6-e0e2-426c-9f48-af33ca081741" />

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交