### PR TITLE
fix: 修复 krc 行时间解析

### DIFF
--- a/src/utils/lyric/parseKRC.ts
+++ b/src/utils/lyric/parseKRC.ts
@@ -31,7 +31,8 @@ export const parseKRC = (text: string, detectBackground = true): LyricLine[] => 
     const header = LINE_HEADER_RE.exec(trimmed);
     if (!header) continue;
 
-    const lineStart = parseTime(header[1], header[2], header[3]);
+    // krc 的时间第三位永远是毫秒数，如 [01:02.3] 实际上是 [01:02.003]，设置 padEndMs = false
+    const lineStart = parseTime(header[1], header[2], header[3], false);
     const rest = trimmed.slice(header[0].length);
 
     WORD_RE.lastIndex = 0;

--- a/src/utils/lyric/timestamp.ts
+++ b/src/utils/lyric/timestamp.ts
@@ -24,15 +24,23 @@ export const ANGLE_TIME_RE = /<(\d+):(\d+)(?:[.:](\d{1,3}))?>([^<]*)/g;
  * @param min 分钟字符串
  * @param sec 秒字符串
  * @param ms 毫秒字符串（1~3 位）
+ * @param padEndMs 是否自动归一化毫秒位数（默认 true）
  * @returns 毫秒数，不超过 MAX_TIME
  */
-export const parseTime = (min: string, sec: string, ms: string): number => {
+export const parseTime = (
+  min: string,
+  sec: string,
+  ms: string,
+  padEndMs: boolean = true,
+): number => {
   const m = parseInt(min, 10);
   const s = parseInt(sec, 10);
   let millis = parseInt(ms, 10) || 0;
 
-  if (ms.length === 1) millis *= 100;
-  else if (ms.length === 2) millis *= 10;
+  if (padEndMs) {
+    if (ms.length === 1) millis *= 100;
+    else if (ms.length === 2) millis *= 10;
+  }
 
   return Math.min(m * 60_000 + s * 1000 + millis, MAX_TIME);
 };


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

krc 的时间第三位永远是毫秒数，如 `[01:02.3]` 实际上是 `[01:02.003]`，之前的解析会解析为 `[01:02.300]` 导致行时间错误

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
