### PR TITLE
fix: 网易云专辑取消收藏api错误

### DIFF
--- a/electron/main/apis/netease/modules/album_sub.ts
+++ b/electron/main/apis/netease/modules/album_sub.ts
@@ -12,7 +12,7 @@ import { createOption } from "../core/option";
 import type { NeteaseModule } from "../core/types";
 
 const albumSub: NeteaseModule = (query, request) => {
-  const path = query.t === 2 ? "/api/album/sub/cancel" : "/api/album/sub";
+  const path = query.t === 2 ? "/api/album/unsub" : "/api/album/sub";
   const data = { id: query.id };
   return request(path, data, createOption(query, "weapi"));
 };


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

网易云取消收藏专辑会报404未找到接口，参考[NeteaseCloudMusicApiEnhanced](https://github.com/neteasecloudmusicapienhanced/api-enhanced)修复。

## 关联 Issue

<!-- 如有关联，填 #编号；写 "Closes #编号" 可在合并时自动关闭对应 Issue -->

## 测试情况

<!-- 如何验证这些改动？手动复现步骤、覆盖到的平台（Windows / macOS / Linux）等 -->

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
