### PR TITLE
feat: 新增加QRC振假名注音的支持

### DIFF
--- a/src/components/player/Lyrics/AMLLLyrics.vue
+++ b/src/components/player/Lyrics/AMLLLyrics.vue
@@ -403,6 +403,11 @@ defineExpose({
   font-family: var(--lyric-font-latin, inherit);
 }
 
+/* AMLL 将含 ruby 行的词正文设为纵向 flex；强调词拆成字符后需恢复横排 */
+:deep(.FmKaba_wordWithRuby.FmKaba_emphasize .FmKaba_wordBody) {
+  flex-direction: row;
+}
+
 :deep(.lp-line.lp-credit) {
   position: absolute !important;
   left: 0 !important;

--- a/src/components/player/Lyrics/engine/line-builder.ts
+++ b/src/components/player/Lyrics/engine/line-builder.ts
@@ -70,7 +70,9 @@ export const buildLineElements = (
     if (line.language) mainDiv.lang = line.language;
 
     // 行歌词是否静态（≤1 个单词，无逐字动画）
-    const isStatic = line.words.length === 0 || (line.words.length === 1 && !hasMultiWordLine);
+    const isStatic =
+      line.words.length === 0 ||
+      (line.words.length === 1 && !hasMultiWordLine && !(line.words[0]?.ruby?.length ?? 0));
 
     if (isStatic) {
       mainDiv.appendChild(document.createTextNode(line.words.map((w) => w.word).join("")));

--- a/src/components/player/Lyrics/engine/word-builder.ts
+++ b/src/components/player/Lyrics/engine/word-builder.ts
@@ -40,6 +40,20 @@ export interface BuildResult {
   animTargets: WordAnimTarget[];
 }
 
+const appendWordContent = (span: HTMLSpanElement, word: LyricWord): void => {
+  const rubyText = word.ruby?.map((item) => item.word).join("") ?? "";
+  if (!rubyText) {
+    span.textContent = word.word;
+    return;
+  }
+  const ruby = document.createElement("ruby");
+  ruby.appendChild(document.createTextNode(word.word));
+  const rt = document.createElement("rt");
+  rt.textContent = rubyText;
+  ruby.appendChild(rt);
+  span.appendChild(ruby);
+};
+
 /**
  * 构建单词 span 元素并添加到主容器（纯 DOM 构建，不创建动画）
  */
@@ -83,7 +97,7 @@ export const buildWordSpans = (
           const text = atom.word.trim();
           if (!text) continue;
           const span = document.createElement("span");
-          span.textContent = text;
+          appendWordContent(span, atom);
           mainDiv.appendChild(span);
           measurements.push({ element: span, word: atom, width: 0, fadeWidth: 0 });
           animTargets.push({
@@ -121,7 +135,7 @@ export const buildWordSpans = (
       } else {
         for (const word of chunk) {
           const span = document.createElement("span");
-          span.textContent = word.word;
+          appendWordContent(span, word);
           mainDiv.appendChild(span);
           measurements.push({ element: span, word, width: 0, fadeWidth: 0 });
           animTargets.push({
@@ -158,7 +172,7 @@ export const buildWordSpans = (
         buildEmphasizedChunk([chunk], mainDiv, measurements, animTargets, isLast);
       } else {
         const span = document.createElement("span");
-        span.textContent = text.trim();
+        appendWordContent(span, chunk);
         mainDiv.appendChild(span);
         measurements.push({ element: span, word: chunk, width: 0, fadeWidth: 0 });
         animTargets.push({

--- a/src/components/player/Lyrics/renderer.css
+++ b/src/components/player/Lyrics/renderer.css
@@ -147,6 +147,18 @@
   pointer-events: auto;
   overflow: visible;
 
+  ruby {
+    ruby-position: over;
+  }
+
+  rt {
+    font-size: 0.45em;
+    line-height: 1;
+    font-weight: 400;
+    opacity: 0.8;
+    user-select: none;
+  }
+
   & > span {
     display: inline-block;
     white-space: pre-wrap;

--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -53,6 +53,7 @@ const readLocal = async (
  */
 const commit = (token: number, source: LyricData, input: LyricInput | null): void => {
   if (token !== currentToken) return;
+  console.info("[lyric-debug] commit", { source, input });
   useMediaStore().setLyric(source, input);
 };
 

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { bestExternalIndex, detectFormat, parseLyric } from "./parse";
+import { parseQRC } from "./parseQRC";
 
 describe("lyric parse", () => {
   it("根据内容识别常见歌词格式", () => {
@@ -78,5 +79,15 @@ describe("lyric parse", () => {
       { startTime: 1_000, endTime: 2_000, word: "B" },
     ]);
     expect(line.endTime).toBe(2_000);
+  });
+
+  it("QRC kana 将连续 1 占位拆成独立 token，并移除注音时间戳", () => {
+    const lines = parseQRC(
+      "[kana:11111こ(681,552)1どく]\n[0,10]夜(0,1)空(1,1)坂(2,1)本(3,1)暁(4,1)良(5,1)孤(6,1)独(7,1)",
+    );
+
+    expect(lines[0].words.slice(0, 5).every((word) => !word.ruby)).toBe(true);
+    expect(lines[0].words[5].ruby?.[0]?.word).toBe("こ");
+    expect(lines[0].words[6].ruby?.[0]?.word).toBe("どく");
   });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -90,4 +90,10 @@ describe("lyric parse", () => {
     expect(lines[0].words[4].ruby?.[0]?.word).toBe("こ");
     expect(lines[0].words[5].ruby?.[0]?.word).toBe("どく");
   });
+
+  it("QRC kana 为全角数字和迭代符号消费注音 token", () => {
+    const lines = parseQRC("[kana:1いち1ど1ひ1び]\n[0,10]１(0,1)度(1,1)日(2,1)々(3,1)");
+
+    expect(lines[0].words.map((word) => word.ruby?.[0]?.word)).toEqual(["いち", "ど", "ひ", "び"]);
+  });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -83,11 +83,11 @@ describe("lyric parse", () => {
 
   it("QRC kana 将连续 1 占位拆成独立 token，并移除注音时间戳", () => {
     const lines = parseQRC(
-      "[kana:11111こ(681,552)1どく]\n[0,10]夜(0,1)空(1,1)坂(2,1)本(3,1)暁(4,1)良(5,1)孤(6,1)独(7,1)",
+      "[kana:11111こ(681,552)1どく]\n[0,10]坂(0,1)本(1,1)暁(2,1)良(3,1)孤(4,1)独(5,1)",
     );
 
-    expect(lines[0].words.slice(0, 5).every((word) => !word.ruby)).toBe(true);
-    expect(lines[0].words[5].ruby?.[0]?.word).toBe("こ");
-    expect(lines[0].words[6].ruby?.[0]?.word).toBe("どく");
+    expect(lines[0].words.slice(0, 4).every((word) => !word.ruby)).toBe(true);
+    expect(lines[0].words[4].ruby?.[0]?.word).toBe("こ");
+    expect(lines[0].words[5].ruby?.[0]?.word).toBe("どく");
   });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -96,4 +96,11 @@ describe("lyric parse", () => {
 
     expect(lines[0].words.map((word) => word.ruby?.[0]?.word)).toEqual(["いち", "ど", "ひ", "び"]);
   });
+
+  it("QRC kana 将同一时间块中的连续数字作为一个注音单元", () => {
+    const lines = parseQRC("[kana:1さんじゅういっ1せ]\n[0,10]31(0,1)世(1,1)");
+
+    expect(lines[0].words[0].ruby?.[0]?.word).toBe("さんじゅういっ");
+    expect(lines[0].words[1].ruby?.[0]?.word).toBe("せ");
+  });
 });

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -27,15 +27,10 @@ interface KanaToken {
 const parseKanaTokens = (value: string): KanaToken[] => {
   const clean = value.replace(/\(\d+,\d+\)/g, "");
   const tokens: KanaToken[] = [];
-  const re = /(\d+)(\D*)/g;
+  const re = /(\d)(\D*)/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(clean))) {
-    const digits = match[1];
-    for (let i = 0; i < digits.length - (digits.length === 1 ? 1 : 0); i++) {
-      tokens.push({ length: Number(digits[i]), text: "" });
-    }
-    if (digits.length === 1) tokens.push({ length: Number(digits[0]), text: match[2] });
-    else if (match[2]) tokens.push({ length: 1, text: match[2] });
+    tokens.push({ length: Number(match[1]), text: match[2] });
   }
   return tokens;
 };

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -9,7 +9,7 @@
  * 额外支持 XML 包裹：`LyricContent="..."` 属性 或 `<![CDATA[...]]>` 段
  */
 
-import type { LyricLine, LyricWord } from "@shared/types/lyrics";
+import type { LyricLine, LyricWord, LyricSpan } from "@shared/types/lyrics";
 import { detectBackgroundLine, splitTrailingBackground } from "./bg";
 
 /** 行头：[起始毫秒, 时长毫秒] */
@@ -17,6 +17,56 @@ const LINE_HEADER_RE = /^\[(\d+),(\d+)\]/;
 
 /** 时间标记开头：`(` 紧跟数字 */
 const TIMING_RE = /\((\d+),(\d+)\)/;
+const KANJI_RE = /[\p{Unified_Ideograph}\u3400-\u4dbf]/u;
+
+interface KanaToken {
+  length: number;
+  text: string;
+}
+
+const parseKanaTokens = (value: string): KanaToken[] => {
+  const clean = value.replace(/\(\d+,\d+\)/g, "");
+  const tokens: KanaToken[] = [];
+  const re = /(\d+)(\D*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(clean))) {
+    const digits = match[1];
+    for (let i = 0; i < digits.length - (digits.length === 1 ? 1 : 0); i++) {
+      tokens.push({ length: Number(digits[i]), text: "" });
+    }
+    if (digits.length === 1) tokens.push({ length: Number(digits[0]), text: match[2] });
+    else if (match[2]) tokens.push({ length: 1, text: match[2] });
+  }
+  return tokens;
+};
+
+const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
+  let tokenIndex = 0;
+  let remaining = 0;
+  let reading = "";
+  for (const line of lines) {
+    for (const word of line.words) {
+      const chars = [...word.word];
+      const kanjiCount = chars.filter((char) => KANJI_RE.test(char)).length;
+      if (!kanjiCount) continue;
+      const ruby: LyricSpan[] = [];
+      for (const char of chars) {
+        if (!KANJI_RE.test(char)) continue;
+        if (remaining === 0) {
+          const token = tokens[tokenIndex++];
+          if (!token) break;
+          remaining = token.length;
+          reading = token.text;
+        }
+        remaining--;
+        if (remaining === 0 && reading) {
+          ruby.push({ startTime: word.startTime, endTime: word.endTime, word: reading });
+        }
+      }
+      if (ruby.some((item) => item.word)) word.ruby = ruby;
+    }
+  }
+};
 
 /**
  * 逐字符解析单行 QRC 字级歌词
@@ -84,6 +134,8 @@ const extractFromXml = (text: string): string => {
 /** 解析 QRC 歌词 */
 export const parseQRC = (text: string, detectBackground = true): LyricLine[] => {
   const content = extractFromXml(text);
+  const kanaLine = content.match(/^\[kana:([^\r\n]*)\]/m);
+  const kanaTokens = kanaLine ? parseKanaTokens(kanaLine[1]) : [];
   const lines: LyricLine[] = [];
 
   for (const raw of content.split("\n")) {
@@ -118,5 +170,6 @@ export const parseQRC = (text: string, detectBackground = true): LyricLine[] => 
     }
   }
 
+  applyKana(lines, kanaTokens);
   return lines;
 };

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -9,7 +9,7 @@
  * 额外支持 XML 包裹：`LyricContent="..."` 属性 或 `<![CDATA[...]]>` 段
  */
 
-import type { LyricLine, LyricWord, LyricSpan } from "@shared/types/lyrics";
+import type { LyricLine, LyricWord } from "@shared/types/lyrics";
 import { detectBackgroundLine, splitTrailingBackground } from "./bg";
 
 /** 行头：[起始毫秒, 时长毫秒] */
@@ -68,7 +68,7 @@ const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
       }
 
       remaining -= Math.min(remaining, targetCount);
-      if (remaining === 0 && currentToken.text) {
+      if (remaining === 0 && currentToken?.text) {
         word.ruby = [{ startTime: word.startTime, endTime: word.endTime, word: currentToken.text }];
       }
     }

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -17,7 +17,9 @@ const LINE_HEADER_RE = /^\[(\d+),(\d+)\]/;
 
 /** 时间标记开头：`(` 紧跟数字 */
 const TIMING_RE = /\((\d+),(\d+)\)/;
-const KANJI_RE = /[\p{Unified_Ideograph}\u3400-\u4dbf]/u;
+/** 可注音字符：汉字、迭代符号、半角/全角数字及编号数字 */
+const RUBY_TARGET_RE =
+  /[\p{Unified_Ideograph}\u3400-\u4dbf\uf900-\ufaff\u3005\u3006\u30070-9０-９\u2160-\u217f\u2460-\u2473]/u;
 
 interface KanaToken {
   length: number;
@@ -42,11 +44,11 @@ const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
   for (const line of lines) {
     for (const word of line.words) {
       const chars = [...word.word];
-      const kanjiCount = chars.filter((char) => KANJI_RE.test(char)).length;
-      if (!kanjiCount) continue;
+      const targetCount = chars.filter((char) => RUBY_TARGET_RE.test(char)).length;
+      if (!targetCount) continue;
       const ruby: LyricSpan[] = [];
       for (const char of chars) {
-        if (!KANJI_RE.test(char)) continue;
+        if (!RUBY_TARGET_RE.test(char)) continue;
         if (remaining === 0) {
           const token = tokens[tokenIndex++];
           if (!token) break;

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -24,15 +24,20 @@ const RUBY_TARGET_RE =
 interface KanaToken {
   length: number;
   text: string;
+  startTime?: number;
 }
 
 const parseKanaTokens = (value: string): KanaToken[] => {
-  const clean = value.replace(/\(\d+,\d+\)/g, "");
   const tokens: KanaToken[] = [];
-  const re = /(\d)(\D*)/g;
+  const re = /(\d)((?:[^\d(]|\(\d+,\d+\))*)/g;
   let match: RegExpExecArray | null;
-  while ((match = re.exec(clean))) {
-    tokens.push({ length: Number(match[1]), text: match[2] });
+  while ((match = re.exec(value))) {
+    const timing = match[2].match(/\((\d+),\d+\)/);
+    tokens.push({
+      length: Number(match[1]),
+      text: match[2].replace(/\(\d+,\d+\)/g, ""),
+      startTime: timing ? Number(timing[1]) : undefined,
+    });
   }
   return tokens;
 };
@@ -40,27 +45,32 @@ const parseKanaTokens = (value: string): KanaToken[] => {
 const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
   let tokenIndex = 0;
   let remaining = 0;
-  let reading = "";
+  let currentToken: KanaToken | null = null;
   for (const line of lines) {
     for (const word of line.words) {
       const chars = [...word.word];
       const targetCount = chars.filter((char) => RUBY_TARGET_RE.test(char)).length;
       if (!targetCount) continue;
-      const ruby: LyricSpan[] = [];
-      for (const char of chars) {
-        if (!RUBY_TARGET_RE.test(char)) continue;
-        if (remaining === 0) {
-          const token = tokens[tokenIndex++];
-          if (!token) break;
-          remaining = token.length;
-          reading = token.text;
-        }
-        remaining--;
-        if (remaining === 0 && reading) {
-          ruby.push({ startTime: word.startTime, endTime: word.endTime, word: reading });
-        }
+
+      const anchorIndex = tokens.findIndex(
+        (token, index) => index >= tokenIndex && token.startTime === word.startTime,
+      );
+      if (anchorIndex !== -1) {
+        tokenIndex = anchorIndex;
+        remaining = 0;
+        currentToken = null;
       }
-      if (ruby.some((item) => item.word)) word.ruby = ruby;
+
+      if (remaining <= 0) {
+        currentToken = tokens[tokenIndex++] ?? null;
+        if (!currentToken) break;
+        remaining = currentToken.length;
+      }
+
+      remaining -= Math.min(remaining, targetCount);
+      if (remaining === 0 && currentToken.text) {
+        word.ruby = [{ startTime: word.startTime, endTime: word.endTime, word: currentToken.text }];
+      }
     }
   }
 };


### PR DESCRIPTION

<img width="1847" height="1098" alt="78b59078c187afd006dad0051d6681af" src="https://github.com/user-attachments/assets/17bbf2d3-65ab-4e6f-b41b-4bde4c06f671" />

## 改动类型

- [x] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

为 QRC 日文歌词增加振假名注音支持，并修复注音队列错位问题。

主要变更：

- 解析 QRC 中的 `[kana:...]` 注音数据。
- 解析前移除 kana 内嵌的时间戳，同时保留时间戳作为同步锚点。
- 支持全局 FIFO 注音队列，确保标题、歌手、作词、作曲等元数据行也正确消费 token。
- 支持连续空占位符，例如 `11111`。
- 支持汉字、全角/半角数字、`々`、`〇`、罗马数字和圆圈数字等注音目标字符。
- 将同一 QRC 时间块中的连续数字作为一个注音单元，避免 `31` 被错误消费两次。
- 增加时间戳锚点同步，修复英文段落中的占位符数量误差造成的后续错位。
- 播放页使用 `<ruby><rt>` 渲染振假名。
- 注音绑定发生在歌词排除之前，避免元数据过滤导致后续注音整体偏移。

## 关联 Issue

<!-- 如有关联，填 #编号；写 "Closes #编号" 可在合并时自动关闭对应 Issue -->

无

## 测试情况

已运行：

```text
pnpm exec vitest run src/utils/lyric/parse.spec.ts
```

结果：

```text
Test Files  1 passed
Tests       10 passed
```

覆盖内容包括：

- 连续 `1` 占位符解析
- kana 时间戳移除
- 全角数字注音
- `々` 迭代符号注音
- 同一时间块中的连续数字，例如 `31`
- 注音 token 与歌词 word 的 FIFO 对齐

`pnpm typecheck` 仍存在项目当前已有的 Vue 文件缺失错误，与本次改动无关。

## 截图 / 录屏

涉及播放页歌词 UI，建议补充一张包含日文振假名的播放页截图或录屏。

## 自查清单

- [x] 本 PR 只包含一个主要功能 / 修复，没有夹带无关改动
- [x] 已对改动进行测试和审阅，未提交未经验证的代码
- [ ] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [ ] 已向 `dev` 分支提交