### PR TITLE
fix: 修复 mpris 在多 artist 时仅传入单字符串

### DIFF
--- a/electron/main/ipc/player.ts
+++ b/electron/main/ipc/player.ts
@@ -30,10 +30,16 @@ import { getMainWindow, setTaskbarProgress } from "@main/window";
 import { store } from "@main/store";
 import { appName, getSongCacheDir } from "@main/utils/config";
 import * as songCache from "@main/services/songCache";
-import { parseArtists, parseAlbum, formatArtists } from "@main/utils/metadata";
+import { parseArtists, parseAlbum, formatArtists, artistNames } from "@main/utils/metadata";
 import { playerLog } from "@main/utils/logger";
 import { ErrorCode } from "@shared/types/errors";
-import type { LoadOptions, RepeatMode, ShuffleMode, PlayerState } from "@shared/types/player";
+import type {
+  Artist,
+  LoadOptions,
+  RepeatMode,
+  ShuffleMode,
+  PlayerState,
+} from "@shared/types/player";
 import type { MediaEvent } from "@main/services/media";
 import { JsPlayerEvent } from "@splayer/audio-engine";
 
@@ -247,13 +253,21 @@ export const registerPlayerIpc = (): void => {
       // 写一次 SMTC/托盘/标题
       const applyDisplay = (
         title: string,
-        artist: string,
+        artists: Artist[],
         album: string,
         coverData: Buffer | undefined,
         durationMs: number,
       ): void => {
-        const header = artist ? `${title} - ${artist}` : title || appName;
-        mediaService.setMetadata({ title, artist, album, coverData, coverUrl, durationMs });
+        const artistText = formatArtists(artists);
+        const header = artistText ? `${title} - ${artistText}` : title || appName;
+        mediaService.setMetadata({
+          title,
+          artists: artistNames(artists),
+          album,
+          coverData,
+          coverUrl,
+          durationMs,
+        });
         mediaService.setPlayState({ status: autoPlay ? "Playing" : "Paused" });
         getMainWindow()?.setTitle(header);
         setTraySongName(header);
@@ -263,13 +277,13 @@ export const registerPlayerIpc = (): void => {
       if (authoritative) {
         applyDisplay(
           authoritative.title || source.split(/[/\\]/).pop() || source,
-          formatArtists(authoritative.artists ?? []),
+          authoritative.artists ?? [],
           authoritative.album?.name ?? "",
           undefined,
           authoritative.duration ?? 0,
         );
       } else {
-        applyDisplay(source.split(/[/\\]/).pop() || source, "", "", undefined, 0);
+        applyDisplay(source.split(/[/\\]/).pop() || source, [], "", undefined, 0);
       }
       const meta = await inst.load(source, cueRange ? false : autoPlay);
       if (cueRange) {
@@ -280,19 +294,16 @@ export const registerPlayerIpc = (): void => {
       const durationMs = toDisplayDurationMs(nativeDurationMs);
       const fallbackTitle = meta.title || source.split(/[/\\]/).pop() || source;
       const displayTitle = authoritative?.title ?? fallbackTitle;
-      const displayArtist = authoritative
-        ? formatArtists(authoritative.artists ?? [])
-        : formatArtists(parseArtists(meta.artist ?? ""));
+      const displayArtists = authoritative
+        ? (authoritative.artists ?? [])
+        : parseArtists(meta.artist ?? "");
       const displayAlbum = authoritative?.album?.name ?? parseAlbum(meta.album ?? "")?.name ?? "";
       // 本地封面
       const localCover = isRemote ? null : (inst.getCoverRaw() ?? null);
-      applyDisplay(displayTitle, displayArtist, displayAlbum, localCover ?? undefined, durationMs);
+      applyDisplay(displayTitle, displayArtists, displayAlbum, localCover ?? undefined, durationMs);
       if (!isRemote) setTaskbarThumbnailCover(meta.cover);
       // Last.fm
-      const primaryArtist =
-        authoritative?.artists?.[0]?.name ??
-        parseArtists(meta.artist ?? "")[0]?.name ??
-        displayArtist;
+      const primaryArtist = displayArtists[0]?.name ?? "";
       lastfm.onTrackLoaded({
         title: displayTitle,
         artist: primaryArtist,
@@ -308,7 +319,7 @@ export const registerPlayerIpc = (): void => {
           if (seq !== loadSeq) return;
           mediaService.setMetadata({
             title: displayTitle,
-            artist: displayArtist,
+            artists: artistNames(displayArtists),
             album: displayAlbum,
             coverData: buf,
             coverUrl,

--- a/electron/main/utils/metadata.ts
+++ b/electron/main/utils/metadata.ts
@@ -28,6 +28,15 @@ export const formatArtists = (artists: Artist[], separator = " / "): string => {
 };
 
 /**
+ * 提取歌手名称数组
+ * @param artists - Artist 数组
+ * @returns 名称数组，已去除空白与空项
+ */
+export const artistNames = (artists: Artist[]): string[] => {
+  return artists.map((artist) => artist.name.trim()).filter(Boolean);
+};
+
+/**
  * 将专辑字符串转为 Album 对象
  * @param raw - 原始专辑名
  * @returns Album 对象，空字符串返回 undefined

--- a/native/media-ctrl/index.d.ts
+++ b/native/media-ctrl/index.d.ts
@@ -53,7 +53,8 @@ export type MediaEventType =  'Play'|
 /** NAPI 层接收的元数据参数 */
 export interface MetadataParam {
   title: string
-  artist: string
+  /** 歌手列表（MPRIS 需要多值，其余平台内部拼接） */
+  artists: Array<string>
   album: string
   /** 封面原始字节（用于系统媒体控件） */
   coverData?: Buffer

--- a/native/media-ctrl/src/discord.rs
+++ b/native/media-ctrl/src/discord.rs
@@ -240,9 +240,10 @@ impl Worker {
             DiscordDisplayMode::Details => StatusDisplayType::Details,
         };
 
+        let artist_text = data.meta.artist_text();
         let mut activity = Activity::new()
             .details(&data.meta.title)
-            .state(&data.meta.artist)
+            .state(&artist_text)
             .activity_type(ActivityType::Listening)
             .assets(assets)
             .buttons(buttons)

--- a/native/media-ctrl/src/lib.rs
+++ b/native/media-ctrl/src/lib.rs
@@ -81,7 +81,7 @@ pub fn on_event(callback: Function<Unknown<'static>, UnknownReturnValue>) -> Res
 pub fn set_metadata(param: MetadataParam) {
     let discord_payload = MetadataPayload {
         title: param.title.clone(),
-        artist: param.artist.clone(),
+        artists: param.artists.clone(),
         album: param.album.clone(),
         cover_data: None,
         cover_url: param.cover_url.clone(),

--- a/native/media-ctrl/src/model.rs
+++ b/native/media-ctrl/src/model.rs
@@ -64,22 +64,32 @@ impl MediaEvent {
     }
 }
 
+/// 多歌手拼接分隔符（与前端 formatArtists 保持一致）
+const ARTIST_SEPARATOR: &str = " / ";
+
 /// 内部使用的元数据（cover_data 已转为 Vec<u8>）
 #[derive(Clone, PartialEq)]
 pub struct MetadataPayload {
     pub title: String,
-    pub artist: String,
+    pub artists: Vec<String>,
     pub album: String,
     pub cover_data: Option<Vec<u8>>,
     pub cover_url: Option<String>,
     pub duration_ms: Option<f64>,
 }
 
+impl MetadataPayload {
+    /// 拼接后的歌手文本，供只接受单一字符串的平台（SMTC / MPNowPlaying / Discord）使用
+    pub fn artist_text(&self) -> String {
+        self.artists.join(ARTIST_SEPARATOR)
+    }
+}
+
 impl fmt::Debug for MetadataPayload {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MetadataPayload")
             .field("title", &self.title)
-            .field("artist", &self.artist)
+            .field("artists", &self.artists)
             .field("album", &self.album)
             .field(
                 "cover_data",
@@ -98,7 +108,8 @@ impl fmt::Debug for MetadataPayload {
 #[napi(object)]
 pub struct MetadataParam {
     pub title: String,
-    pub artist: String,
+    /// 歌手列表（MPRIS 需要多值，其余平台内部拼接）
+    pub artists: Vec<String>,
     pub album: String,
     /// 封面原始字节（用于系统媒体控件）
     pub cover_data: Option<Buffer>,
@@ -112,7 +123,7 @@ impl From<MetadataParam> for MetadataPayload {
     fn from(p: MetadataParam) -> Self {
         Self {
             title: p.title,
-            artist: p.artist,
+            artists: p.artists,
             album: p.album,
             cover_data: p.cover_data.map(|b| b.to_vec()),
             cover_url: p.cover_url,

--- a/native/media-ctrl/src/sys_media/linux.rs
+++ b/native/media-ctrl/src/sys_media/linux.rs
@@ -193,7 +193,7 @@ async fn process_metadata(
 
     let mut mb = Metadata::builder()
         .title(payload.title)
-        .artist([payload.artist])
+        .artist(payload.artists)
         .album(payload.album);
 
     let track_id = SystemTime::now()

--- a/native/media-ctrl/src/sys_media/macos.rs
+++ b/native/media-ctrl/src/sys_media/macos.rs
@@ -331,7 +331,7 @@ impl SystemMediaControls for MacosImpl {
                 ProtocolObject::from_ref(MPMediaItemPropertyTitle),
             );
             info.setObject_forKey(
-                &NSString::from_str(&payload.artist),
+                &NSString::from_str(&payload.artist_text()),
                 ProtocolObject::from_ref(MPMediaItemPropertyArtist),
             );
             info.setObject_forKey(

--- a/native/media-ctrl/src/sys_media/windows.rs
+++ b/native/media-ctrl/src/sys_media/windows.rs
@@ -291,7 +291,7 @@ impl SystemMediaControls for WindowsImpl {
         let generation = ctx.cover_generation;
 
         let title = payload.title.clone();
-        let artist = payload.artist.clone();
+        let artist = payload.artist_text();
         let album = payload.album.clone();
         let cover_data = payload.cover_data;
         if update_display(ctx, &title, &artist, &album, None).is_err() {


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

MPRIS 的 `xesam:artist` 接受一个字符串列表，所以现在向 `media-ctrl` 传入一个 `Vec<String>` 作为 `artists` 而不是单个字符串，并在不支持以列表形式传入 artist 的平台以 ` / ` 拼接为字符串

## 测试情况

部分代码由 AI 生成，均已经人工审核，并在本机的 Arch Linux 上测试通过

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
