### PR TITLE
feat: 新增加QRC歌词振假名注音的支持

### DIFF
--- a/src/components/player/Lyrics/AMLLLyrics.vue
+++ b/src/components/player/Lyrics/AMLLLyrics.vue
@@ -4,6 +4,7 @@ import { LyricPlayer as CoreLyricPlayer } from "@applemusic-like-lyrics/core";
 import { useSettingsStore } from "@/stores/settings";
 import { useStatusStore } from "@/stores/status";
 import { getCurrentTime } from "@/services/playback";
+import { observeAmllRubyLayout } from "./utils/amll-ruby-layout";
 import "@applemusic-like-lyrics/core/style.css";
 import "./renderer.css";
 
@@ -55,6 +56,7 @@ const status = useStatusStore();
 
 const wrapperRef = ref<HTMLDivElement | null>(null);
 const playerRef = ref<CoreLyricPlayer>();
+let stopRubyLayout: (() => void) | undefined;
 const bottomLineEl = ref<HTMLElement>();
 const clockInitialized = ref(false);
 // 播放器是否已初始化完成
@@ -184,6 +186,7 @@ onMounted(async () => {
   el.style.width = "100%";
   el.style.height = "100%";
   wrapperRef.value.appendChild(el);
+  stopRubyLayout = observeAmllRubyLayout(player);
 
   const bottomEl = player.getBottomLineElement();
   if (bottomEl) {
@@ -231,6 +234,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  stopRubyLayout?.();
+  stopRubyLayout = undefined;
   document.removeEventListener("visibilitychange", handleVisibility);
   pauseRaf();
   initialized.value = false;
@@ -406,6 +411,40 @@ defineExpose({
 /* AMLL 将含 ruby 行的词正文设为纵向 flex；强调词拆成字符后需恢复横排 */
 :deep(.FmKaba_wordWithRuby.FmKaba_emphasize .FmKaba_wordBody) {
   flex-direction: row;
+}
+
+:deep(.FmKaba_lyricMainLine .FmKaba_rubyWord) {
+  width: 0;
+  overflow: visible;
+}
+
+:deep(.FmKaba_rubyWord > span) {
+  flex-shrink: 0;
+  white-space: pre;
+}
+
+:deep(.FmKaba_lyricMainLine .FmKaba_wordWithRuby) {
+  padding: var(--amll-ruby-padding, 1em);
+  margin: calc(-1 * var(--amll-ruby-padding, 1em));
+}
+
+:deep(.FmKaba_lyricLine:has(.FmKaba_rubyWord > span)) {
+  contain: layout style;
+  content-visibility: visible;
+  overflow: visible;
+}
+
+.amll-lyrics-container:has(.FmKaba_rubyWord > span),
+:deep(.amll-lyric-player:has(.FmKaba_rubyWord > span)),
+:deep(.amll-lyric-player:has(.FmKaba_rubyWord > span) .FmKaba_lyricMainLine),
+:deep(.amll-lyric-player:has(.FmKaba_rubyWord > span) .FmKaba_wordWithRuby),
+:deep(.amll-lyric-player:has(.FmKaba_rubyWord > span) .FmKaba_rubyWord) {
+  overflow: visible !important;
+  contain: none !important;
+}
+
+:deep(.amll-lyric-player:has(.FmKaba_rubyWord > span)) {
+  mix-blend-mode: normal !important;
 }
 
 :deep(.lp-line.lp-credit) {

--- a/src/components/player/Lyrics/AMLLLyrics.vue
+++ b/src/components/player/Lyrics/AMLLLyrics.vue
@@ -416,6 +416,7 @@ defineExpose({
 :deep(.FmKaba_lyricMainLine .FmKaba_rubyWord) {
   width: 0;
   overflow: visible;
+  translate: var(--amll-ruby-offset, 0px) 0;
 }
 
 :deep(.FmKaba_rubyWord > span) {

--- a/src/components/player/Lyrics/AMLLLyrics.vue
+++ b/src/components/player/Lyrics/AMLLLyrics.vue
@@ -403,6 +403,11 @@ defineExpose({
   font-family: var(--lyric-font-latin, inherit);
 }
 
+/* AMLL 将含 ruby 行的词正文设为纵向 flex；强调词拆成字符后需恢复横排 */
+:deep(.FmKaba_wordWithRuby.FmKaba_emphasize .FmKaba_wordBody) {
+  flex-direction: row;
+}
+
 :deep(.lp-line.lp-credit) {
   position: absolute !important;
   left: 0 !important;

--- a/src/components/player/Lyrics/engine/index.ts
+++ b/src/components/player/Lyrics/engine/index.ts
@@ -183,8 +183,6 @@ export class LyricRenderer {
   private containerResizeObserver: ResizeObserver;
   /** 哨兵行尺寸观察器（检测字体/样式变化） */
   private sentinelResizeObserver: ResizeObserver;
-  /** 哨兵行元素 */
-  private sentinelElement: HTMLDivElement | null = null;
 
   /** bottom-line 容器 */
   private bottomLineEl!: HTMLDivElement;
@@ -257,16 +255,7 @@ export class LyricRenderer {
   resume = () => {
     if (this.animationFrameId !== 0) return;
     this.containerResizeObserver.observe(this.container);
-    if (this.sentinelElement) {
-      this.sentinelResizeObserver.observe(this.sentinelElement);
-    }
-    for (const measurements of this.wordMeasurements) {
-      for (const { element } of measurements) {
-        if (element.tagName !== "RT") continue;
-        this.sentinelResizeObserver.observe(element);
-        this.sentinelResizeObserver.observe(element.previousElementSibling!);
-      }
-    }
+    this.observeTextSizes();
     this.lastFrameTimestamp = 0;
     this.needsFullSync = true;
     // 冻结期间播放进度可能大幅前进，恢复后的首次时间推送若检测到跳变则瞬移布局
@@ -379,19 +368,7 @@ export class LyricRenderer {
 
     // 哨兵观察器：监听第一行尺寸变化以检测字体/样式变化
     this.sentinelResizeObserver.disconnect();
-    this.sentinelElement = null;
-    if (lineCount > 0) {
-      this.sentinelElement = this.lineElements[0];
-      this.sentinelResizeObserver.observe(this.sentinelElement);
-    }
-    // 注音绝对定位，字体变化可能只改变其宽度而不改变哨兵行高度。
-    for (const measurements of this.wordMeasurements) {
-      for (const { element } of measurements) {
-        if (element.tagName !== "RT") continue;
-        this.sentinelResizeObserver.observe(element);
-        this.sentinelResizeObserver.observe(element.previousElementSibling!);
-      }
-    }
+    this.observeTextSizes();
 
     // 测量尺寸 + 计算 CSS mask
     this.dotsContainerWidth = this.dotsContainer.offsetWidth || 60;
@@ -1158,6 +1135,19 @@ export class LyricRenderer {
     }
     this.calculateLayout(true);
     this.needsFullSync = true;
+  };
+
+  /** 注音绝对定位，需同时监听正文和注音宽度，覆盖行高不变的字体变化。 */
+  private observeTextSizes = (): void => {
+    const firstLine = this.lineElements[0];
+    if (firstLine) this.sentinelResizeObserver.observe(firstLine);
+    for (const measurements of this.wordMeasurements) {
+      for (const { element } of measurements) {
+        if (element.tagName !== "RT") continue;
+        this.sentinelResizeObserver.observe(element);
+        this.sentinelResizeObserver.observe(element.previousElementSibling!);
+      }
+    }
   };
 
   /** 取 bottom-line 容器 */

--- a/src/components/player/Lyrics/engine/index.ts
+++ b/src/components/player/Lyrics/engine/index.ts
@@ -260,6 +260,13 @@ export class LyricRenderer {
     if (this.sentinelElement) {
       this.sentinelResizeObserver.observe(this.sentinelElement);
     }
+    for (const measurements of this.wordMeasurements) {
+      for (const { element } of measurements) {
+        if (element.tagName !== "RT") continue;
+        this.sentinelResizeObserver.observe(element);
+        this.sentinelResizeObserver.observe(element.previousElementSibling!);
+      }
+    }
     this.lastFrameTimestamp = 0;
     this.needsFullSync = true;
     // 冻结期间播放进度可能大幅前进，恢复后的首次时间推送若检测到跳变则瞬移布局
@@ -376,6 +383,14 @@ export class LyricRenderer {
     if (lineCount > 0) {
       this.sentinelElement = this.lineElements[0];
       this.sentinelResizeObserver.observe(this.sentinelElement);
+    }
+    // 注音绝对定位，字体变化可能只改变其宽度而不改变哨兵行高度。
+    for (const measurements of this.wordMeasurements) {
+      for (const { element } of measurements) {
+        if (element.tagName !== "RT") continue;
+        this.sentinelResizeObserver.observe(element);
+        this.sentinelResizeObserver.observe(element.previousElementSibling!);
+      }
     }
 
     // 测量尺寸 + 计算 CSS mask

--- a/src/components/player/Lyrics/engine/line-builder.ts
+++ b/src/components/player/Lyrics/engine/line-builder.ts
@@ -70,7 +70,9 @@ export const buildLineElements = (
     if (line.language) mainDiv.lang = line.language;
 
     // 行歌词是否静态（≤1 个单词，无逐字动画）
-    const isStatic = line.words.length === 0 || (line.words.length === 1 && !hasMultiWordLine);
+    const isStatic =
+      line.words.length === 0 ||
+      (line.words.length === 1 && !hasMultiWordLine && !(line.words[0]?.ruby?.length ?? 0));
 
     if (isStatic) {
       mainDiv.appendChild(document.createTextNode(line.words.map((w) => w.word).join("")));

--- a/src/components/player/Lyrics/engine/ruby-layout.spec.ts
+++ b/src/components/player/Lyrics/engine/ruby-layout.spec.ts
@@ -4,6 +4,11 @@ import type { LyricWord } from "@shared/types/lyrics";
 
 beforeEach(() => document.body.replaceChildren());
 
+const story: [string, string, number, number][] = [
+  ["物", "もの", 40, 36],
+  ["語", "がたり", 40, 54],
+];
+
 const createLine = (texts: [string, string, number, number][], emphasize = false) => {
   const main = document.createElement("div");
   main.className = "lp-main";
@@ -42,13 +47,7 @@ const createLine = (texts: [string, string, number, number][], emphasize = false
 
 describe("physics 引擎 Ruby 合排", () => {
   it.each([false, true])("物語整体居中，并保留逐词掩码（强调效果：%s）", (emphasize) => {
-    const fixture = createLine(
-      [
-        ["物", "もの", 40, 36],
-        ["語", "がたり", 40, 54],
-      ],
-      emphasize,
-    );
+    const fixture = createLine(story, emphasize);
     fixture.measure();
     expect(fixture.offsets()).toEqual([-7, -2]);
     expect(
@@ -80,10 +79,7 @@ describe("physics 引擎 Ruby 合排", () => {
   });
 
   it("字体变更后重新测量并恢复独立居中", () => {
-    const fixture = createLine([
-      ["物", "もの", 40, 36],
-      ["語", "がたり", 40, 54],
-    ]);
+    const fixture = createLine(story);
     fixture.measure();
     fixture.rtWidths[1] = 30;
     fixture.measure();
@@ -91,11 +87,7 @@ describe("physics 引擎 Ruby 合排", () => {
   });
 
   it("空格隔开的汉字不合并", () => {
-    const fixture = createLine([
-      ["物", "もの", 40, 36],
-      [" ", "", 0, 0],
-      ["語", "がたり", 40, 54],
-    ]);
+    const fixture = createLine([story[0], [" ", "", 0, 0], story[1]]);
     fixture.measure();
     expect(fixture.offsets()).toEqual([0, 0]);
   });

--- a/src/components/player/Lyrics/engine/ruby-layout.spec.ts
+++ b/src/components/player/Lyrics/engine/ruby-layout.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildWordSpans, measureAndApplyWordMasks } from "./word-builder";
+import type { LyricWord } from "@shared/types/lyrics";
+
+beforeEach(() => document.body.replaceChildren());
+
+const createLine = (texts: [string, string, number, number][], emphasize = false) => {
+  const main = document.createElement("div");
+  main.className = "lp-main";
+  document.body.append(main);
+  Object.defineProperty(main, "offsetWidth", { value: 600 });
+  main.getBoundingClientRect = () => new DOMRect(0, 0, 600, 80);
+  const words: LyricWord[] = texts.map(([word, ruby], index) => ({
+    word,
+    startTime: index * 2500,
+    endTime: (index + 1) * 2500,
+    ruby: ruby ? [{ word: ruby, startTime: index * 2500, endTime: (index + 1) * 2500 }] : [],
+  }));
+  const result = buildWordSpans(words, main, emphasize);
+  let left = 0;
+  const rubies = Array.from(main.querySelectorAll("ruby"));
+  const dimensions = texts.filter(([, ruby]) => ruby);
+  const rtWidths: number[] = [];
+  rubies.forEach((ruby, index) => {
+    const [, , width, rubyWidth] = dimensions[index];
+    ruby.style.fontSize = "40px";
+    const x = left;
+    ruby.firstElementChild!.getBoundingClientRect = () => new DOMRect(x, 0, width, 40);
+    rtWidths[index] = rubyWidth;
+    ruby.lastElementChild!.getBoundingClientRect = () => new DOMRect(0, 0, rtWidths[index], 18);
+    left += width;
+  });
+  const measure = () => measureAndApplyWordMasks([result.measurements], 0.5);
+  const offsets = () =>
+    rubies.map((ruby) =>
+      Number.parseFloat(
+        (ruby.lastElementChild as HTMLElement).style.getPropertyValue("--lp-ruby-offset"),
+      ),
+    );
+  return { main, words, result, rubies, rtWidths, measure, offsets };
+};
+
+describe("physics 引擎 Ruby 合排", () => {
+  it.each([false, true])("物語整体居中，并保留逐词掩码（强调效果：%s）", (emphasize) => {
+    const fixture = createLine(
+      [
+        ["物", "もの", 40, 36],
+        ["語", "がたり", 40, 54],
+      ],
+      emphasize,
+    );
+    fixture.measure();
+    expect(fixture.offsets()).toEqual([-7, -2]);
+    expect(
+      fixture.result.measurements
+        .filter(({ element }) => element.tagName === "RT")
+        .map(({ word }) => word),
+    ).toEqual(fixture.words);
+    const rt = fixture.rubies[1].lastElementChild as HTMLElement;
+    expect(rt.style.getPropertyValue("mask-position")).toContain("2420");
+    expect(fixture.main.querySelectorAll("ruby")).toHaveLength(2);
+  });
+
+  it("最後保持逐字注音", () => {
+    const fixture = createLine([
+      ["最", "さい", 40, 36],
+      ["後", "ご", 40, 18],
+    ]);
+    fixture.measure();
+    expect(fixture.offsets()).toEqual([0, 0]);
+  });
+
+  it("整体注音的汉字组也参与合排", () => {
+    const fixture = createLine([
+      ["天球", "てんきゅうう", 80, 110],
+      ["儀", "ぎ", 40, 36],
+    ]);
+    fixture.measure();
+    expect(fixture.offsets()).toEqual([2, 15]);
+  });
+
+  it("字体变更后重新测量并恢复独立居中", () => {
+    const fixture = createLine([
+      ["物", "もの", 40, 36],
+      ["語", "がたり", 40, 54],
+    ]);
+    fixture.measure();
+    fixture.rtWidths[1] = 30;
+    fixture.measure();
+    expect(fixture.offsets()).toEqual([0, 0]);
+  });
+
+  it("空格隔开的汉字不合并", () => {
+    const fixture = createLine([
+      ["物", "もの", 40, 36],
+      [" ", "", 0, 0],
+      ["語", "がたり", 40, 54],
+    ]);
+    fixture.measure();
+    expect(fixture.offsets()).toEqual([0, 0]);
+  });
+});

--- a/src/components/player/Lyrics/engine/word-builder.ts
+++ b/src/components/player/Lyrics/engine/word-builder.ts
@@ -6,7 +6,7 @@ import { chunkAndSplitLyricWords } from "../utils/split-words";
 import type { LyricLine, LyricWord } from "@shared/types/lyrics";
 import { needsSpaceBetween } from "../utils/split-words";
 import { shouldChunkEmphasize } from "./emphasize";
-import { alignRubyGroups, type RubyLayoutItem } from "../utils/ruby-layout";
+import { alignRubyGroups, measureRuby, type RubyLayoutItem } from "../utils/ruby-layout";
 
 /** 单个歌词单词的 DOM 元素与测量数据 */
 export interface WordMeasurement {
@@ -267,7 +267,7 @@ export const measureAndApplyWordMasks = (
 ) => {
   // 临时存储每个 measurement 的 padding，供第二遍使用
   const paddings: number[][] = new Array(wordMeasurements.length);
-  const rubyUpdates: [HTMLElement, number][] = [];
+  const rubyUpdates: RubyLayoutItem[] = [];
 
   // ===== 第一遍：批量读取 DOM 尺寸（一次回流） =====
   for (let i = 0; i < wordMeasurements.length; i++) {
@@ -277,7 +277,7 @@ export const measureAndApplyWordMasks = (
       continue;
     }
     paddings[i] = new Array(lineMeasurements.length);
-    const rubyItems: (RubyLayoutItem & { ruby: HTMLElement })[] = [];
+    const rubyItems: RubyLayoutItem[] = [];
     let lineScale = 0;
     for (let j = 0; j < lineMeasurements.length; j++) {
       const m = lineMeasurements[j];
@@ -296,27 +296,16 @@ export const measureAndApplyWordMasks = (
           lineScale = main.getBoundingClientRect().width / main.offsetWidth;
         }
         if (!lineScale) continue;
-        const rect = body.getBoundingClientRect();
-        rubyItems.push({
-          word,
-          ruby: el,
-          text: m.word.word,
-          left: rect.left / lineScale,
-          top: rect.top / lineScale,
-          width: rect.width / lineScale,
-          rubyWidth: el.getBoundingClientRect().width / lineScale,
-          fontSize: Number.parseFloat(getComputedStyle(word).fontSize),
-          offset: 0,
-        });
+        rubyItems.push(measureRuby(word, body, el, lineScale));
       }
     }
     if (rubyItems.length) {
       alignRubyGroups(rubyItems);
-      rubyItems.forEach(({ ruby, offset }) => rubyUpdates.push([ruby, offset]));
+      rubyUpdates.push(...rubyItems);
     }
   }
 
-  for (const [ruby, offset] of rubyUpdates) {
+  for (const { ruby, offset } of rubyUpdates) {
     ruby.style.setProperty("--lp-ruby-offset", `${offset.toFixed(3)}px`);
   }
 

--- a/src/components/player/Lyrics/engine/word-builder.ts
+++ b/src/components/player/Lyrics/engine/word-builder.ts
@@ -6,6 +6,7 @@ import { chunkAndSplitLyricWords } from "../utils/split-words";
 import type { LyricLine, LyricWord } from "@shared/types/lyrics";
 import { needsSpaceBetween } from "../utils/split-words";
 import { shouldChunkEmphasize } from "./emphasize";
+import { alignRubyGroups, type RubyLayoutItem } from "../utils/ruby-layout";
 
 /** 单个歌词单词的 DOM 元素与测量数据 */
 export interface WordMeasurement {
@@ -266,6 +267,7 @@ export const measureAndApplyWordMasks = (
 ) => {
   // 临时存储每个 measurement 的 padding，供第二遍使用
   const paddings: number[][] = new Array(wordMeasurements.length);
+  const rubyUpdates: [HTMLElement, number][] = [];
 
   // ===== 第一遍：批量读取 DOM 尺寸（一次回流） =====
   for (let i = 0; i < wordMeasurements.length; i++) {
@@ -275,6 +277,8 @@ export const measureAndApplyWordMasks = (
       continue;
     }
     paddings[i] = new Array(lineMeasurements.length);
+    const rubyItems: (RubyLayoutItem & { ruby: HTMLElement })[] = [];
+    let lineScale = 0;
     for (let j = 0; j < lineMeasurements.length; j++) {
       const m = lineMeasurements[j];
       const el = m.element;
@@ -284,7 +288,36 @@ export const measureAndApplyWordMasks = (
       paddings[i][j] = padding;
       m.width = (el.clientWidth || 1) - padding * 2;
       m.fadeWidth = ((el.clientHeight || 16) - padding * 2) * fadeRatio;
+      if (el.tagName === "RT") {
+        const word = el.parentElement!;
+        const body = el.previousElementSibling!;
+        if (!lineScale) {
+          const main = word.closest<HTMLElement>(".lp-main")!;
+          lineScale = main.getBoundingClientRect().width / main.offsetWidth;
+        }
+        if (!lineScale) continue;
+        const rect = body.getBoundingClientRect();
+        rubyItems.push({
+          word,
+          ruby: el,
+          text: m.word.word,
+          left: rect.left / lineScale,
+          top: rect.top / lineScale,
+          width: rect.width / lineScale,
+          rubyWidth: el.getBoundingClientRect().width / lineScale,
+          fontSize: Number.parseFloat(getComputedStyle(word).fontSize),
+          offset: 0,
+        });
+      }
     }
+    if (rubyItems.length) {
+      alignRubyGroups(rubyItems);
+      rubyItems.forEach(({ ruby, offset }) => rubyUpdates.push([ruby, offset]));
+    }
+  }
+
+  for (const [ruby, offset] of rubyUpdates) {
+    ruby.style.setProperty("--lp-ruby-offset", `${offset.toFixed(3)}px`);
   }
 
   // ===== 第二遍：批量写入 CSS mask 样式（零回流） =====

--- a/src/components/player/Lyrics/engine/word-builder.ts
+++ b/src/components/player/Lyrics/engine/word-builder.ts
@@ -40,6 +40,20 @@ export interface BuildResult {
   animTargets: WordAnimTarget[];
 }
 
+const appendWordContent = (span: HTMLSpanElement, word: LyricWord): void => {
+  const rubyText = word.ruby?.map((item) => item.word).join("") ?? "";
+  if (!rubyText) {
+    span.textContent = word.word;
+    return;
+  }
+  const ruby = document.createElement("ruby");
+  ruby.appendChild(document.createTextNode(word.word));
+  const rt = document.createElement("rt");
+  rt.textContent = rubyText;
+  ruby.appendChild(rt);
+  span.appendChild(ruby);
+};
+
 /**
  * 构建单词 span 元素并添加到主容器（纯 DOM 构建，不创建动画）
  */
@@ -83,7 +97,7 @@ export const buildWordSpans = (
           const text = atom.word.trim();
           if (!text) continue;
           const span = document.createElement("span");
-          span.textContent = text;
+          appendWordContent(span, atom);
           mainDiv.appendChild(span);
           measurements.push({ element: span, word: atom, width: 0, fadeWidth: 0 });
           animTargets.push({
@@ -121,7 +135,7 @@ export const buildWordSpans = (
       } else {
         for (const word of chunk) {
           const span = document.createElement("span");
-          span.textContent = word.word;
+          appendWordContent(span, word);
           mainDiv.appendChild(span);
           measurements.push({ element: span, word, width: 0, fadeWidth: 0 });
           animTargets.push({
@@ -158,7 +172,7 @@ export const buildWordSpans = (
         buildEmphasizedChunk([chunk], mainDiv, measurements, animTargets, isLast);
       } else {
         const span = document.createElement("span");
-        span.textContent = text.trim();
+        appendWordContent(span, chunk);
         mainDiv.appendChild(span);
         measurements.push({ element: span, word: chunk, width: 0, fadeWidth: 0 });
         animTargets.push({

--- a/src/components/player/Lyrics/engine/word-builder.ts
+++ b/src/components/player/Lyrics/engine/word-builder.ts
@@ -9,8 +9,8 @@ import { shouldChunkEmphasize } from "./emphasize";
 
 /** 单个歌词单词的 DOM 元素与测量数据 */
 export interface WordMeasurement {
-  /** 对应的 span 元素 */
-  element: HTMLSpanElement;
+  /** 独立应用掩码的主体或注音元素 */
+  element: HTMLElement;
   /** 歌词单词数据 */
   word: LyricWord;
   /** 元素宽度（px） */
@@ -40,18 +40,29 @@ export interface BuildResult {
   animTargets: WordAnimTarget[];
 }
 
-const appendWordContent = (span: HTMLSpanElement, word: LyricWord): void => {
+const appendWordContent = (
+  span: HTMLSpanElement,
+  word: LyricWord,
+  measurements: WordMeasurement[],
+): void => {
   const rubyText = word.ruby?.map((item) => item.word).join("") ?? "";
   if (!rubyText) {
     span.textContent = word.word;
+    measurements.push({ element: span, word, width: 0, fadeWidth: 0 });
     return;
   }
   const ruby = document.createElement("ruby");
-  ruby.appendChild(document.createTextNode(word.word));
+  const base = document.createElement("span");
+  base.textContent = word.word;
+  ruby.appendChild(base);
   const rt = document.createElement("rt");
   rt.textContent = rubyText;
   ruby.appendChild(rt);
   span.appendChild(ruby);
+  measurements.push(
+    { element: base, word, width: 0, fadeWidth: 0 },
+    { element: rt, word, width: 0, fadeWidth: 0 },
+  );
 };
 
 /**
@@ -97,9 +108,8 @@ export const buildWordSpans = (
           const text = atom.word.trim();
           if (!text) continue;
           const span = document.createElement("span");
-          appendWordContent(span, atom);
+          appendWordContent(span, atom, measurements);
           mainDiv.appendChild(span);
-          measurements.push({ element: span, word: atom, width: 0, fadeWidth: 0 });
           animTargets.push({
             element: span,
             word: atom,
@@ -135,9 +145,8 @@ export const buildWordSpans = (
       } else {
         for (const word of chunk) {
           const span = document.createElement("span");
-          appendWordContent(span, word);
+          appendWordContent(span, word, measurements);
           mainDiv.appendChild(span);
-          measurements.push({ element: span, word, width: 0, fadeWidth: 0 });
           animTargets.push({
             element: span,
             word,
@@ -172,9 +181,8 @@ export const buildWordSpans = (
         buildEmphasizedChunk([chunk], mainDiv, measurements, animTargets, isLast);
       } else {
         const span = document.createElement("span");
-        appendWordContent(span, chunk);
+        appendWordContent(span, chunk, measurements);
         mainDiv.appendChild(span);
-        measurements.push({ element: span, word: chunk, width: 0, fadeWidth: 0 });
         animTargets.push({
           element: span,
           word: chunk,
@@ -216,15 +224,26 @@ function buildEmphasizedChunk(
   wrapper.className = "lp-emp-wrapper";
 
   const charElements: HTMLElement[] = [];
-  for (const char of trimmed) {
-    const charSpan = document.createElement("span");
-    charSpan.textContent = char;
-    wrapper.appendChild(charSpan);
-    charElements.push(charSpan);
+  const hasRuby = atoms.some((atom) => atom.ruby?.some((ruby) => ruby.word));
+  if (hasRuby) {
+    for (const atom of atoms) {
+      const atomSpan = document.createElement("span");
+      atomSpan.className = "lp-emp-atom";
+      appendWordContent(atomSpan, atom, measurements);
+      wrapper.appendChild(atomSpan);
+      charElements.push(atomSpan);
+    }
+  } else {
+    for (const char of trimmed) {
+      const charSpan = document.createElement("span");
+      charSpan.textContent = char;
+      wrapper.appendChild(charSpan);
+      charElements.push(charSpan);
+    }
+    measurements.push({ element: wrapper, word: mergedWord, width: 0, fadeWidth: 0 });
   }
 
   mainDiv.appendChild(wrapper);
-  measurements.push({ element: wrapper, word: mergedWord, width: 0, fadeWidth: 0 });
   animTargets.push({
     element: wrapper,
     word: mergedWord,
@@ -259,7 +278,7 @@ export const measureAndApplyWordMasks = (
     for (let j = 0; j < lineMeasurements.length; j++) {
       const m = lineMeasurements[j];
       const el = m.element;
-      const padding = el.classList.contains("lp-emp-wrapper")
+      const padding = el.matches(".lp-emp-wrapper, .lp-emp-atom")
         ? Number.parseFloat(getComputedStyle(el).paddingLeft) || 0
         : 0;
       paddings[i][j] = padding;

--- a/src/components/player/Lyrics/renderer.css
+++ b/src/components/player/Lyrics/renderer.css
@@ -175,6 +175,7 @@
     left: 50%;
     width: max-content;
     transform: translateX(-50%);
+    translate: var(--lp-ruby-offset, 0px) 0;
     white-space: pre;
     font-size: 0.45em;
     line-height: 1;

--- a/src/components/player/Lyrics/renderer.css
+++ b/src/components/player/Lyrics/renderer.css
@@ -147,6 +147,18 @@
   pointer-events: auto;
   overflow: visible;
 
+  ruby {
+    ruby-position: over;
+  }
+
+  rt {
+    font-size: 0.45em;
+    line-height: 1;
+    font-weight: 400;
+    opacity: 0.8;
+    user-select: none;
+  }
+
   & > span {
     display: inline-block;
     white-space: pre-wrap;

--- a/src/components/player/Lyrics/renderer.css
+++ b/src/components/player/Lyrics/renderer.css
@@ -93,6 +93,15 @@
   margin-left: auto;
 }
 
+.lp-root:has(ruby) {
+  overflow: visible clip;
+  contain: size layout style;
+}
+
+.lp-line:has(ruby) {
+  contain: layout style;
+}
+
 /* ---- 对唱左右分栏 ---- */
 
 .lp-has-duet {
@@ -148,10 +157,25 @@
   overflow: visible;
 
   ruby {
-    ruby-position: over;
+    position: relative;
+    display: inline-block;
+    padding-top: 0.5em;
+    white-space: pre;
+    overflow: visible;
+
+    & > span {
+      display: inline-block;
+    }
   }
 
   rt {
+    position: absolute;
+    display: block;
+    top: 0;
+    left: 50%;
+    width: max-content;
+    transform: translateX(-50%);
+    white-space: pre;
     font-size: 0.45em;
     line-height: 1;
     font-weight: 400;

--- a/src/components/player/Lyrics/utils/amll-ruby-layout.spec.ts
+++ b/src/components/player/Lyrics/utils/amll-ruby-layout.spec.ts
@@ -111,13 +111,20 @@ describe("AMLL 连续汉字注音布局", () => {
     expect(first.ruby.style.visibility).toBe("");
   });
 
-  it("最後未溢出时保留逐字居中", () => {
-    const fixture = createFixture();
-    const first = fixture.add("最", 40, [["さい", 40]]);
-    const last = fixture.add("後", 40, [["ご", 20]]);
-    stop = observeAmllRubyLayout(fixture.player);
-    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
-  });
+  it.each([
+    ["未溢出", "最", "さい", 40, 40, "後", "ご", 20],
+    ["注音较长但未溢出", "天球", "てんきゅう", 80, 50, "儀", "ぎ", 20],
+    ["有溢出但未碰撞", "物", "もの", 40, 20, "語", "がたり", 50],
+  ] as const)(
+    "%s 时保留逐词居中",
+    (_, text, reading, width, rubyWidth, lastText, lastReading, lastWidth) => {
+      const fixture = createFixture();
+      const first = fixture.add(text, width, [[reading, rubyWidth]]);
+      const last = fixture.add(lastText, 40, [[lastReading, lastWidth]]);
+      stop = observeAmllRubyLayout(fixture.player);
+      expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+    },
+  );
 
   it("按像素宽度处理汉字组及多个注音时间片段", () => {
     const fixture = createFixture();
@@ -129,22 +136,6 @@ describe("AMLL 连续汉字注音布局", () => {
     stop = observeAmllRubyLayout(fixture.player);
     expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 15]);
     expect(first.ruby.children).toHaveLength(2);
-  });
-
-  it("字符数较长但物理宽度未溢出时不合并", () => {
-    const fixture = createFixture();
-    const first = fixture.add("天球", 80, [["てんきゅう", 50]]);
-    const last = fixture.add("儀", 40, [["ぎ", 20]]);
-    stop = observeAmllRubyLayout(fixture.player);
-    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
-  });
-
-  it("溢出注音与相邻注音没有碰撞时不合并", () => {
-    const fixture = createFixture();
-    const first = fixture.add("物", 40, [["もの", 20]]);
-    const last = fixture.add("語", 40, [["がたり", 50]]);
-    stop = observeAmllRubyLayout(fixture.player);
-    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
   });
 
   it("中间词溢出时左右关联汉字都参与合排", () => {

--- a/src/components/player/Lyrics/utils/amll-ruby-layout.spec.ts
+++ b/src/components/player/Lyrics/utils/amll-ruby-layout.spec.ts
@@ -1,0 +1,255 @@
+import type { LyricPlayer } from "@applemusic-like-lyrics/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { observeAmllRubyLayout } from "./amll-ruby-layout";
+
+let resize: () => void;
+let mutate: () => void;
+let stop: (() => void) | undefined;
+const observe = vi.fn();
+const unobserve = vi.fn();
+const disconnect = vi.fn();
+
+const createFixture = (scale = 1) => {
+  const root = document.createElement("div");
+  const line = document.createElement("div");
+  line.className = "FmKaba_lyricMainLine";
+  root.append(line);
+  document.body.append(root);
+  Object.defineProperty(root, "clientWidth", { value: 600, configurable: true });
+  Object.defineProperty(line, "offsetWidth", { value: 600 });
+  line.getBoundingClientRect = () => new DOMRect(0, 0, 600 * scale, 80 * scale);
+  const updateMaskImageSync = vi.fn();
+  const player = {
+    getElement: () => root,
+    currentLyricGroups: [{ mainLine: { getElement: () => line, updateMaskImageSync } }],
+  } as unknown as LyricPlayer;
+  let left = 0;
+
+  const add = (text: string, width: number, rubyParts: [string, number][], top = 0) => {
+    const wrapper = document.createElement("span");
+    wrapper.className = "FmKaba_emphasizeWrapper";
+    const word = document.createElement("span");
+    word.className = "FmKaba_wordWithRuby";
+    word.style.fontSize = "40px";
+    const body = document.createElement("div");
+    body.className = "FmKaba_wordBody";
+    body.textContent = text;
+    const bounds = { left, top, width };
+    body.getBoundingClientRect = () =>
+      new DOMRect(bounds.left * scale, bounds.top * scale, bounds.width * scale, 40 * scale);
+    const ruby = document.createElement("div");
+    ruby.className = "FmKaba_rubyWord";
+    const parts = rubyParts.map(([content, partWidth], index) => {
+      const element = document.createElement("span");
+      element.textContent = content;
+      element.dataset.startTime = String(index * 100);
+      element.dataset.endTime = String((index + 1) * 100);
+      const part = { element, width: partWidth };
+      element.getBoundingClientRect = () => new DOMRect(0, 0, part.width * scale, 20 * scale);
+      ruby.append(element);
+      return part;
+    });
+    word.append(ruby, body);
+    wrapper.append(word);
+    line.append(wrapper);
+    left += width;
+    return { word, body, ruby, parts, bounds, wrapper };
+  };
+  return { root, line, player, add, updateMaskImageSync };
+};
+
+const offset = (ruby: HTMLElement): number =>
+  Number.parseFloat(ruby.style.getPropertyValue("--amll-ruby-offset"));
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  vi.spyOn(document, "hidden", "get").mockReturnValue(false);
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: () => void) {
+        resize = callback;
+      }
+      observe = observe;
+      unobserve = unobserve;
+      disconnect = disconnect;
+    },
+  );
+  vi.stubGlobal(
+    "MutationObserver",
+    class {
+      constructor(callback: () => void) {
+        mutate = callback;
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+    },
+  );
+});
+
+afterEach(() => {
+  stop?.();
+  stop = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("AMLL 连续汉字注音布局", () => {
+  it("将物語的注音连续排列，并以整词中心居中", () => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    const last = fixture.add("語", 40, [["がたり", 60]]);
+    stop = observeAmllRubyLayout(fixture.player);
+
+    expect(offset(first.ruby)).toBe(-10);
+    expect(offset(last.ruby)).toBe(0);
+    const firstLeft = 20 + offset(first.ruby) - 20;
+    const lastLeft = 60 + offset(last.ruby) - 30;
+    expect(firstLeft + 40).toBe(lastLeft);
+    expect((firstLeft + lastLeft + 60) / 2).toBe(40);
+    expect(first.ruby.firstElementChild).toBe(first.parts[0].element);
+    expect(last.parts[0].element.dataset.endTime).toBe("100");
+    expect(first.ruby.style.visibility).toBe("");
+  });
+
+  it("最後未溢出时保留逐字居中", () => {
+    const fixture = createFixture();
+    const first = fixture.add("最", 40, [["さい", 40]]);
+    const last = fixture.add("後", 40, [["ご", 20]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("按像素宽度处理汉字组及多个注音时间片段", () => {
+    const fixture = createFixture();
+    const first = fixture.add("天球", 80, [
+      ["てん", 45],
+      ["きゅう", 65],
+    ]);
+    const last = fixture.add("儀", 40, [["ぎ", 40]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 15]);
+    expect(first.ruby.children).toHaveLength(2);
+  });
+
+  it("字符数较长但物理宽度未溢出时不合并", () => {
+    const fixture = createFixture();
+    const first = fixture.add("天球", 80, [["てんきゅう", 50]]);
+    const last = fixture.add("儀", 40, [["ぎ", 20]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("溢出注音与相邻注音没有碰撞时不合并", () => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 20]]);
+    const last = fixture.add("語", 40, [["がたり", 50]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("中间词溢出时左右关联汉字都参与合排", () => {
+    const fixture = createFixture();
+    const first = fixture.add("新", 40, [["しん", 40]]);
+    const middle = fixture.add("物", 40, [["もの", 70]]);
+    const last = fixture.add("語", 40, [["がたり", 40]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(middle.ruby), offset(last.ruby)]).toEqual([-15, 0, 15]);
+  });
+
+  it.each([" ", "、", "の"])("不跨过文本节点 %s 合并", (separator) => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    fixture.line.append(document.createTextNode(separator));
+    const last = fixture.add("語", 40, [["がたり", 60]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it.each(["の", "、", "天球の", "A"])("非连续汉字 %s 断开合并", (text) => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    fixture.add(text, 40, [["かな", 60]]);
+    const last = fixture.add("語", 40, [["がたり", 60]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("无注音汉字与空注音容器断开合并", () => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    fixture.add("語", 40, []);
+    const last = fixture.add("天球", 80, [["てんきゅう", 100]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("不跨视觉换行合并", () => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    const last = fixture.add("語", 40, [["がたり", 60]], 60);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("剔除行缩放影响，并允许单词上浮动画产生的高度差", () => {
+    const fixture = createFixture(0.75);
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    const last = fixture.add("語", 40, [["がたり", 60]], -2);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([-10, 0]);
+  });
+
+  it("字体变化后解除合并，稳定布局不重复更新掩码或注册观察", () => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    const last = fixture.add("語", 40, [["がたり", 60]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    const observations = observe.mock.calls.length;
+    resize();
+    expect(observe).toHaveBeenCalledTimes(observations);
+    expect(fixture.updateMaskImageSync).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+    last.parts[0].width = 30;
+    resize();
+    expect([offset(first.ruby), offset(last.ruby)]).toEqual([0, 0]);
+  });
+
+  it("长注音合排后仍有足够的掩码空间", () => {
+    const fixture = createFixture();
+    const first = fixture.add("天球", 80, [["てんきゅう", 240]]);
+    const last = fixture.add("儀", 40, [["ぎ", 40]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    for (const item of [first, last]) {
+      const required = Math.abs(offset(item.ruby)) + (item.parts[0].width - item.bounds.width) / 2;
+      expect(
+        Number.parseFloat(item.word.style.getPropertyValue("--amll-ruby-padding")),
+      ).toBeGreaterThan(required);
+    }
+  });
+
+  it("歌词替换后释放旧节点的尺寸监听", () => {
+    const fixture = createFixture();
+    const old = fixture.add("語", 40, [["がたり", 60]]);
+    stop = observeAmllRubyLayout(fixture.player);
+    old.wrapper.remove();
+    fixture.add("最", 40, [["さい", 40]]);
+    mutate();
+    expect(unobserve).toHaveBeenCalledWith(old.body);
+    expect(unobserve).toHaveBeenCalledWith(old.parts[0].element);
+  });
+
+  it("初始隐藏时在恢复可见后计算布局", () => {
+    const fixture = createFixture();
+    const first = fixture.add("物", 40, [["もの", 40]]);
+    fixture.add("語", 40, [["がたり", 60]]);
+    const hidden = vi.spyOn(document, "hidden", "get").mockReturnValue(true);
+    stop = observeAmllRubyLayout(fixture.player);
+    expect(first.ruby.style.getPropertyValue("--amll-ruby-offset")).toBe("");
+    hidden.mockReturnValue(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(offset(first.ruby)).toBe(-10);
+    stop();
+    stop = undefined;
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/player/Lyrics/utils/amll-ruby-layout.ts
+++ b/src/components/player/Lyrics/utils/amll-ruby-layout.ts
@@ -1,0 +1,45 @@
+import type { LyricPlayer } from "@applemusic-like-lyrics/core";
+
+/**
+ * 按注音实际宽度扩展 AMLL 单词的掩码绘制空间，负外边距由样式抵消。
+ * @param player - AMLL 播放器
+ * @returns 解除尺寸与 DOM 监听的清理函数
+ */
+export const observeAmllRubyLayout = (player: LyricPlayer): (() => void) => {
+  const root = player.getElement();
+  const sync = (): void => {
+    if (!root.isConnected || root.clientWidth === 0) return;
+    const targets = new Set<HTMLElement>();
+    const updates: [HTMLElement, string][] = [];
+    for (const word of root.querySelectorAll<HTMLElement>(".FmKaba_wordWithRuby")) {
+      const ruby = word.querySelector<HTMLElement>(".FmKaba_rubyWord");
+      const body = word.querySelector<HTMLElement>(".FmKaba_wordBody");
+      if (!ruby?.childElementCount || !body) continue;
+      targets.add(word);
+      targets.add(ruby);
+      targets.add(body);
+      const fontSize = Number.parseFloat(getComputedStyle(word).fontSize);
+      const padding = `${Math.ceil(Math.max(fontSize, (ruby.scrollWidth - body.offsetWidth) / 2 + 1))}px`;
+      if (word.style.getPropertyValue("--amll-ruby-padding") !== padding)
+        updates.push([word, padding]);
+    }
+    resizeObserver.disconnect();
+    targets.forEach((target) => resizeObserver.observe(target));
+    updates.forEach(([word, padding]) => word.style.setProperty("--amll-ruby-padding", padding));
+    if (!updates.length) return;
+    for (const group of player.currentLyricGroups) {
+      for (const line of [group.mainLine, group.bgLine]) {
+        if (line && updates.some(([word]) => line.getElement().contains(word)))
+          line.updateMaskImageSync();
+      }
+    }
+  };
+  const resizeObserver = new ResizeObserver(sync);
+  const mutationObserver = new MutationObserver(sync);
+  mutationObserver.observe(root, { childList: true, subtree: true });
+  sync();
+  return () => {
+    mutationObserver.disconnect();
+    resizeObserver.disconnect();
+  };
+};

--- a/src/components/player/Lyrics/utils/amll-ruby-layout.ts
+++ b/src/components/player/Lyrics/utils/amll-ruby-layout.ts
@@ -1,45 +1,107 @@
 import type { LyricPlayer } from "@applemusic-like-lyrics/core";
+import { alignRubyGroups, type RubyLayoutItem } from "./ruby-layout";
+
+interface RubyMeasurement extends RubyLayoutItem {
+  ruby: HTMLElement;
+}
 
 /**
- * 按注音实际宽度扩展 AMLL 单词的掩码绘制空间，负外边距由样式抵消。
+ * 按实际宽度合排连续汉字注音，并扩展掩码空间；保留原节点与逐词时间轴。
  * @param player - AMLL 播放器
  * @returns 解除尺寸与 DOM 监听的清理函数
  */
 export const observeAmllRubyLayout = (player: LyricPlayer): (() => void) => {
   const root = player.getElement();
+  const observed = new Set<HTMLElement>();
+
   const sync = (): void => {
-    if (!root.isConnected || root.clientWidth === 0) return;
-    const targets = new Set<HTMLElement>();
-    const updates: [HTMLElement, string][] = [];
-    for (const word of root.querySelectorAll<HTMLElement>(".FmKaba_wordWithRuby")) {
-      const ruby = word.querySelector<HTMLElement>(".FmKaba_rubyWord");
-      const body = word.querySelector<HTMLElement>(".FmKaba_wordBody");
-      if (!ruby?.childElementCount || !body) continue;
-      targets.add(word);
-      targets.add(ruby);
-      targets.add(body);
-      const fontSize = Number.parseFloat(getComputedStyle(word).fontSize);
-      const padding = `${Math.ceil(Math.max(fontSize, (ruby.scrollWidth - body.offsetWidth) / 2 + 1))}px`;
-      if (word.style.getPropertyValue("--amll-ruby-padding") !== padding)
-        updates.push([word, padding]);
+    if (document.hidden || !root.isConnected || root.clientWidth === 0) return;
+    const targets = new Set<HTMLElement>([root]);
+    const measurements: RubyMeasurement[] = [];
+
+    for (const line of root.querySelectorAll<HTMLElement>(".FmKaba_lyricMainLine")) {
+      targets.add(line);
+      const scale = line.getBoundingClientRect().width / line.offsetWidth;
+      if (!scale) continue;
+      const lineMeasurements: RubyMeasurement[] = [];
+
+      for (const word of line.querySelectorAll<HTMLElement>(".FmKaba_wordWithRuby")) {
+        const ruby = word.querySelector<HTMLElement>(".FmKaba_rubyWord");
+        const body = word.querySelector<HTMLElement>(".FmKaba_wordBody");
+        if (!ruby || !body) continue;
+        targets.add(body);
+        const parts = Array.from(ruby.children) as HTMLElement[];
+        parts.forEach((part) => targets.add(part));
+        const rect = body.getBoundingClientRect();
+        const item: RubyMeasurement = {
+          word,
+          ruby,
+          text: Array.from(body.childNodes)
+            .filter((node) => !(node instanceof Element && node.matches(".FmKaba_romanWord")))
+            .map((node) => node.textContent ?? "")
+            .join(""),
+          left: rect.left / scale,
+          top: rect.top / scale,
+          width: rect.width / scale,
+          // 零宽 flex 容器的 scrollWidth 不包含向左溢出的部分，需测量全部注音片段。
+          rubyWidth: parts.reduce(
+            (sum, part) => sum + part.getBoundingClientRect().width / scale,
+            0,
+          ),
+          fontSize: Number.parseFloat(getComputedStyle(word).fontSize),
+          offset: 0,
+        };
+        lineMeasurements.push(item);
+      }
+      alignRubyGroups(lineMeasurements);
+      measurements.push(...lineMeasurements);
     }
-    resizeObserver.disconnect();
-    targets.forEach((target) => resizeObserver.observe(target));
-    updates.forEach(([word, padding]) => word.style.setProperty("--amll-ruby-padding", padding));
-    if (!updates.length) return;
+
+    for (const target of observed) {
+      if (!targets.has(target)) {
+        resizeObserver.unobserve(target);
+        observed.delete(target);
+      }
+    }
+    for (const target of targets) {
+      if (!observed.has(target)) {
+        resizeObserver.observe(target);
+        observed.add(target);
+      }
+    }
+
+    const changedWords = new Set<HTMLElement>();
+    for (const item of measurements) {
+      const { word, ruby, offset, rubyWidth, width, fontSize } = item;
+      const shift = `${offset.toFixed(3)}px`;
+      if (ruby.style.getPropertyValue("--amll-ruby-offset") !== shift)
+        ruby.style.setProperty("--amll-ruby-offset", shift);
+      const padding = `${Math.ceil(Math.max(fontSize, Math.abs(offset) + (rubyWidth - width) / 2 + 1))}px`;
+      if (word.style.getPropertyValue("--amll-ruby-padding") !== padding) {
+        word.style.setProperty("--amll-ruby-padding", padding);
+        changedWords.add(word);
+      }
+    }
+    if (!changedWords.size) return;
     for (const group of player.currentLyricGroups) {
       for (const line of [group.mainLine, group.bgLine]) {
-        if (line && updates.some(([word]) => line.getElement().contains(word)))
+        if (line && Array.from(changedWords).some((word) => line.getElement().contains(word)))
           line.updateMaskImageSync();
       }
     }
   };
+
   const resizeObserver = new ResizeObserver(sync);
   const mutationObserver = new MutationObserver(sync);
-  mutationObserver.observe(root, { childList: true, subtree: true });
+  mutationObserver.observe(root, { childList: true, characterData: true, subtree: true });
+  resizeObserver.observe(root);
+  observed.add(root);
+  document.addEventListener("visibilitychange", sync);
   sync();
   return () => {
     mutationObserver.disconnect();
     resizeObserver.disconnect();
+    observed.clear();
+    document.removeEventListener("visibilitychange", sync);
   };
 };

--- a/src/components/player/Lyrics/utils/amll-ruby-layout.ts
+++ b/src/components/player/Lyrics/utils/amll-ruby-layout.ts
@@ -1,9 +1,5 @@
 import type { LyricPlayer } from "@applemusic-like-lyrics/core";
-import { alignRubyGroups, type RubyLayoutItem } from "./ruby-layout";
-
-interface RubyMeasurement extends RubyLayoutItem {
-  ruby: HTMLElement;
-}
+import { alignRubyGroups, measureRuby, type RubyLayoutItem } from "./ruby-layout";
 
 /**
  * 按实际宽度合排连续汉字注音，并扩展掩码空间；保留原节点与逐词时间轴。
@@ -12,80 +8,54 @@ interface RubyMeasurement extends RubyLayoutItem {
  */
 export const observeAmllRubyLayout = (player: LyricPlayer): (() => void) => {
   const root = player.getElement();
-  const observed = new Set<HTMLElement>();
+  let observed = new Set<HTMLElement>();
 
   const sync = (): void => {
     if (document.hidden || !root.isConnected || root.clientWidth === 0) return;
     const targets = new Set<HTMLElement>([root]);
-    const measurements: RubyMeasurement[] = [];
+    const measurements: RubyLayoutItem[] = [];
 
     for (const line of root.querySelectorAll<HTMLElement>(".FmKaba_lyricMainLine")) {
       targets.add(line);
       const scale = line.getBoundingClientRect().width / line.offsetWidth;
       if (!scale) continue;
-      const lineMeasurements: RubyMeasurement[] = [];
+      const lineMeasurements: RubyLayoutItem[] = [];
 
       for (const word of line.querySelectorAll<HTMLElement>(".FmKaba_wordWithRuby")) {
         const ruby = word.querySelector<HTMLElement>(".FmKaba_rubyWord");
         const body = word.querySelector<HTMLElement>(".FmKaba_wordBody");
         if (!ruby || !body) continue;
         targets.add(body);
-        const parts = Array.from(ruby.children) as HTMLElement[];
-        parts.forEach((part) => targets.add(part));
-        const rect = body.getBoundingClientRect();
-        const item: RubyMeasurement = {
-          word,
-          ruby,
-          text: Array.from(body.childNodes)
-            .filter((node) => !(node instanceof Element && node.matches(".FmKaba_romanWord")))
-            .map((node) => node.textContent ?? "")
-            .join(""),
-          left: rect.left / scale,
-          top: rect.top / scale,
-          width: rect.width / scale,
-          // 零宽 flex 容器的 scrollWidth 不包含向左溢出的部分，需测量全部注音片段。
-          rubyWidth: parts.reduce(
-            (sum, part) => sum + part.getBoundingClientRect().width / scale,
-            0,
-          ),
-          fontSize: Number.parseFloat(getComputedStyle(word).fontSize),
-          offset: 0,
-        };
-        lineMeasurements.push(item);
+        for (const part of ruby.children) targets.add(part as HTMLElement);
+        lineMeasurements.push(measureRuby(word, body, ruby, scale));
       }
       alignRubyGroups(lineMeasurements);
       measurements.push(...lineMeasurements);
     }
 
     for (const target of observed) {
-      if (!targets.has(target)) {
-        resizeObserver.unobserve(target);
-        observed.delete(target);
-      }
+      if (!targets.has(target)) resizeObserver.unobserve(target);
     }
     for (const target of targets) {
-      if (!observed.has(target)) {
-        resizeObserver.observe(target);
-        observed.add(target);
-      }
+      if (!observed.has(target)) resizeObserver.observe(target);
     }
+    observed = targets;
 
-    const changedWords = new Set<HTMLElement>();
-    for (const item of measurements) {
-      const { word, ruby, offset, rubyWidth, width, fontSize } = item;
+    const changedWords: HTMLElement[] = [];
+    for (const { word, ruby, offset, rubyWidth, width, fontSize } of measurements) {
       const shift = `${offset.toFixed(3)}px`;
       if (ruby.style.getPropertyValue("--amll-ruby-offset") !== shift)
         ruby.style.setProperty("--amll-ruby-offset", shift);
       const padding = `${Math.ceil(Math.max(fontSize, Math.abs(offset) + (rubyWidth - width) / 2 + 1))}px`;
       if (word.style.getPropertyValue("--amll-ruby-padding") !== padding) {
         word.style.setProperty("--amll-ruby-padding", padding);
-        changedWords.add(word);
+        changedWords.push(word);
       }
     }
-    if (!changedWords.size) return;
+    if (!changedWords.length) return;
     for (const group of player.currentLyricGroups) {
       for (const line of [group.mainLine, group.bgLine]) {
-        if (line && Array.from(changedWords).some((word) => line.getElement().contains(word)))
+        if (line && changedWords.some((word) => line.getElement().contains(word)))
           line.updateMaskImageSync();
       }
     }

--- a/src/components/player/Lyrics/utils/ruby-layout.ts
+++ b/src/components/player/Lyrics/utils/ruby-layout.ts
@@ -1,0 +1,60 @@
+export interface RubyLayoutItem {
+  word: HTMLElement;
+  text: string;
+  left: number;
+  top: number;
+  width: number;
+  rubyWidth: number;
+  fontSize: number;
+  offset: number;
+}
+
+const HAN_GROUP = /^(?:[\p{Script=Han}\u3005\u3006]\p{Variation_Selector}?)+$/u;
+
+/**
+ * 连续汉字注音发生碰撞时合排整组，以正文范围的中心对齐注音总宽度。
+ * @param items - 同一歌词行中按 DOM 顺序测量的注音，尺寸已去除行缩放
+ */
+export const alignRubyGroups = (items: RubyLayoutItem[]): void => {
+  const between = document.createRange();
+  let group: RubyLayoutItem[] = [];
+  const flush = (): void => {
+    const overflowing = group.some((item) => item.rubyWidth > item.width + 0.5);
+    const overlapping = group.some((item, index) => {
+      const previous = group[index - 1];
+      return (
+        previous &&
+        previous.left + (previous.width + previous.rubyWidth) / 2 >
+          item.left + (item.width - item.rubyWidth) / 2 + 0.5
+      );
+    });
+    if (overflowing && overlapping) {
+      const first = group[0];
+      const last = group[group.length - 1];
+      const rubyWidth = group.reduce((sum, item) => sum + item.rubyWidth, 0);
+      let left = (first.left + last.left + last.width - rubyWidth) / 2;
+      for (const item of group) {
+        item.offset = left + item.rubyWidth / 2 - (item.left + item.width / 2);
+        left += item.rubyWidth;
+      }
+    }
+    group = [];
+  };
+
+  for (const item of items) {
+    item.offset = 0;
+    if (!item.rubyWidth || !HAN_GROUP.test(item.text)) {
+      flush();
+      continue;
+    }
+    const previous = group[group.length - 1];
+    if (previous) {
+      // 跨词容器检查真实文本间隔；上浮动画的小幅高度差不应被当作换行。
+      between.setStartAfter(previous.word);
+      between.setEndBefore(item.word);
+      if (between.toString() || Math.abs(item.top - previous.top) > item.fontSize / 2) flush();
+    }
+    group.push(item);
+  }
+  flush();
+};

--- a/src/components/player/Lyrics/utils/ruby-layout.ts
+++ b/src/components/player/Lyrics/utils/ruby-layout.ts
@@ -1,5 +1,6 @@
 export interface RubyLayoutItem {
   word: HTMLElement;
+  ruby: HTMLElement;
   text: string;
   left: number;
   top: number;
@@ -10,6 +11,32 @@ export interface RubyLayoutItem {
 }
 
 const HAN_GROUP = /^(?:[\p{Script=Han}\u3005\u3006]\p{Variation_Selector}?)+$/u;
+
+/** 测量正文与注音的实际尺寸，排除行缩放和正文容器中的逐词罗马音。 */
+export const measureRuby = (
+  word: HTMLElement,
+  body: Element,
+  ruby: HTMLElement,
+  scale: number,
+): RubyLayoutItem => {
+  const rect = body.getBoundingClientRect();
+  // AMLL 的零宽容器会向两侧溢出，需累加子片段；原生 rt 直接测量自身。
+  const parts = ruby.childElementCount ? Array.from(ruby.children) : [ruby];
+  return {
+    word,
+    ruby,
+    text: Array.from(body.childNodes)
+      .filter((node) => !(node instanceof Element && node.matches(".FmKaba_romanWord")))
+      .map((node) => node.textContent ?? "")
+      .join(""),
+    left: rect.left / scale,
+    top: rect.top / scale,
+    width: rect.width / scale,
+    rubyWidth: parts.reduce((sum, part) => sum + part.getBoundingClientRect().width / scale, 0),
+    fontSize: Number.parseFloat(getComputedStyle(word).fontSize),
+    offset: 0,
+  };
+};
 
 /**
  * 连续汉字注音发生碰撞时合排整组，以正文范围的中心对齐注音总宽度。

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -752,6 +752,7 @@
       "lyricTTML": "TTML Lyrics",
       "lyricExclude": "Metadata Stripping",
       "lyricGeneral": "Content & Style",
+      "lyricQrcKana": "QRC Japanese Ruby",
       "lyricDisplay": "Display Effects",
       "lyricAMLLOptimize": "Lyric Optimization",
       "lyricSpring": "Spring Animation",
@@ -1169,6 +1170,10 @@
     "amllShowWordRomanization": {
       "label": "Show Word Romanization",
       "description": "Display romanized lyrics for each word in word-by-word lyrics"
+    },
+    "showQrcKana": {
+      "label": "Show Japanese Ruby",
+      "description": "Only applies to QRC lyric sources"
     },
     "enableWordHighlight": {
       "label": "Word Highlight",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -740,6 +740,7 @@
       "lyricTTML": "TTML 歌词",
       "lyricExclude": "歌词排除",
       "lyricGeneral": "内容样式",
+      "lyricQrcKana": "QRC 日语注音",
       "lyricDisplay": "显示效果",
       "lyricAMLLOptimize": "歌词优化",
       "lyricSpring": "弹簧动画",
@@ -1157,6 +1158,10 @@
     "amllShowWordRomanization": {
       "label": "显示逐词音译",
       "description": "在逐字歌词中，显示每个字词的音译文本"
+    },
+    "showQrcKana": {
+      "label": "显示日语注音",
+      "description": "仅在 QRC 歌词源时生效"
     },
     "enableWordHighlight": {
       "label": "逐字高亮",

--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -53,6 +53,7 @@ const readLocal = async (
  */
 const commit = (token: number, source: LyricData, input: LyricInput | null): void => {
   if (token !== currentToken) return;
+  console.info("[lyric-debug] commit", { source, input });
   useMediaStore().setLyric(source, input);
 };
 

--- a/src/settings/categories/lyric.ts
+++ b/src/settings/categories/lyric.ts
@@ -228,6 +228,17 @@ const lyricCategory: SettingCategory = {
       ],
     },
     {
+      id: "lyricQrcKana",
+      items: [
+        {
+          key: "showQrcKana",
+          type: "switch",
+          binding: { store: "settings", path: "lyric.showQrcKana" },
+          defaultValue: true,
+        },
+      ],
+    },
+    {
       id: "lyricDisplay",
       items: [
         {

--- a/src/stores/media.ts
+++ b/src/stores/media.ts
@@ -137,7 +137,11 @@ export const useMediaStore = defineStore("media", () => {
 
   // 监听简繁转换及强迫症设置变化并重新解析当前歌词
   watch(
-    () => [useSettingsStore().lyric.cjkTransform, useSettingsStore().preset.uncensorProfanity],
+    () => [
+      useSettingsStore().lyric.cjkTransform,
+      useSettingsStore().lyric.showQrcKana,
+      useSettingsStore().preset.uncensorProfanity,
+    ],
     () => {
       if (activeLyric.value && lyricContent.value) {
         setLyric(activeLyric.value, lyricContent.value);
@@ -157,6 +161,7 @@ export const useMediaStore = defineStore("media", () => {
       try {
         const lines = parseLyric(input, source.format, settings.locale, {
           detectBackground: settings.lyric.detectBackgroundLyrics,
+          showQrcKana: settings.lyric.showQrcKana,
         });
         nextLines = applyLyricExclude(lines, track.value);
         normalizeLyricLines(nextLines);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -182,6 +182,7 @@ export const useSettingsStore = defineStore(
       fontFamilyChinese: "",
       showTranslation: true,
       showRomanization: true,
+      showQrcKana: true,
       amllShowLineRomanization: true,
       amllShowWordRomanization: true,
       enableWordHighlight: true,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -141,6 +141,8 @@ export interface LyricSettings {
   showTranslation: boolean;
   /** 是否显示音译歌词 */
   showRomanization: boolean;
+  /** 是否显示 QRC 日语注音 */
+  showQrcKana: boolean;
   /** AMLL 是否显示逐行音译 */
   amllShowLineRomanization: boolean;
   /** AMLL 是否显示逐词音译 */

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { bestExternalIndex, detectFormat, parseLyric } from "./parse";
+import { parseQRC } from "./parseQRC";
 
 describe("lyric parse", () => {
   it("根据内容识别常见歌词格式", () => {
@@ -78,5 +79,15 @@ describe("lyric parse", () => {
       { startTime: 1_000, endTime: 2_000, word: "B" },
     ]);
     expect(line.endTime).toBe(2_000);
+  });
+
+  it("QRC kana 将连续 1 占位拆成独立 token，并移除注音时间戳", () => {
+    const lines = parseQRC(
+      "[kana:11111こ(681,552)1どく]\n[0,10]夜(0,1)空(1,1)坂(2,1)本(3,1)暁(4,1)良(5,1)孤(6,1)独(7,1)",
+    );
+
+    expect(lines[0].words.slice(0, 5).every((word) => !word.ruby)).toBe(true);
+    expect(lines[0].words[5].ruby?.[0]?.word).toBe("こ");
+    expect(lines[0].words[6].ruby?.[0]?.word).toBe("どく");
   });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -90,4 +90,10 @@ describe("lyric parse", () => {
     expect(lines[0].words[4].ruby?.[0]?.word).toBe("こ");
     expect(lines[0].words[5].ruby?.[0]?.word).toBe("どく");
   });
+
+  it("QRC kana 为全角数字和迭代符号消费注音 token", () => {
+    const lines = parseQRC("[kana:1いち1ど1ひ1び]\n[0,10]１(0,1)度(1,1)日(2,1)々(3,1)");
+
+    expect(lines[0].words.map((word) => word.ruby?.[0]?.word)).toEqual(["いち", "ど", "ひ", "び"]);
+  });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -83,11 +83,11 @@ describe("lyric parse", () => {
 
   it("QRC kana 将连续 1 占位拆成独立 token，并移除注音时间戳", () => {
     const lines = parseQRC(
-      "[kana:11111こ(681,552)1どく]\n[0,10]夜(0,1)空(1,1)坂(2,1)本(3,1)暁(4,1)良(5,1)孤(6,1)独(7,1)",
+      "[kana:11111こ(681,552)1どく]\n[0,10]坂(0,1)本(1,1)暁(2,1)良(3,1)孤(4,1)独(5,1)",
     );
 
-    expect(lines[0].words.slice(0, 5).every((word) => !word.ruby)).toBe(true);
-    expect(lines[0].words[5].ruby?.[0]?.word).toBe("こ");
-    expect(lines[0].words[6].ruby?.[0]?.word).toBe("どく");
+    expect(lines[0].words.slice(0, 4).every((word) => !word.ruby)).toBe(true);
+    expect(lines[0].words[4].ruby?.[0]?.word).toBe("こ");
+    expect(lines[0].words[5].ruby?.[0]?.word).toBe("どく");
   });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -103,4 +103,12 @@ describe("lyric parse", () => {
     expect(lines[0].words[0].ruby?.[0]?.word).toBe("さんじゅういっ");
     expect(lines[0].words[1].ruby?.[0]?.word).toBe("せ");
   });
+
+  it("QRC 可关闭日语注音而不影响主体歌词", () => {
+    const [line] = parseLyric({ content: "[kana:1ひかり]\n[0,10]光(0,10)" }, "qrc", "", {
+      showQrcKana: false,
+    });
+    expect(line.words[0]?.ruby).toBeUndefined();
+    expect(line.words[0]?.word).toBe("光");
+  });
 });

--- a/src/utils/lyric/parse.spec.ts
+++ b/src/utils/lyric/parse.spec.ts
@@ -96,4 +96,11 @@ describe("lyric parse", () => {
 
     expect(lines[0].words.map((word) => word.ruby?.[0]?.word)).toEqual(["いち", "ど", "ひ", "び"]);
   });
+
+  it("QRC kana 将同一时间块中的连续数字作为一个注音单元", () => {
+    const lines = parseQRC("[kana:1さんじゅういっ1せ]\n[0,10]31(0,1)世(1,1)");
+
+    expect(lines[0].words[0].ruby?.[0]?.word).toBe("さんじゅういっ");
+    expect(lines[0].words[1].ruby?.[0]?.word).toBe("せ");
+  });
 });

--- a/src/utils/lyric/parse.ts
+++ b/src/utils/lyric/parse.ts
@@ -12,6 +12,7 @@ import { normalizeKangxi } from "./kangxi";
 
 export interface ParseLyricOptions {
   detectBackground?: boolean;
+  showQrcKana?: boolean;
 }
 
 /**
@@ -84,7 +85,7 @@ const parseContent = (
     case "ttml":
       return parseTTML(text, preferredLang);
     case "qrc":
-      return parseQRC(text, detectBackground);
+      return parseQRC(text, detectBackground, options.showQrcKana !== false);
     case "krc":
       return parseKRC(text, detectBackground);
     case "yrc":

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -27,15 +27,10 @@ interface KanaToken {
 const parseKanaTokens = (value: string): KanaToken[] => {
   const clean = value.replace(/\(\d+,\d+\)/g, "");
   const tokens: KanaToken[] = [];
-  const re = /(\d+)(\D*)/g;
+  const re = /(\d)(\D*)/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(clean))) {
-    const digits = match[1];
-    for (let i = 0; i < digits.length - (digits.length === 1 ? 1 : 0); i++) {
-      tokens.push({ length: Number(digits[i]), text: "" });
-    }
-    if (digits.length === 1) tokens.push({ length: Number(digits[0]), text: match[2] });
-    else if (match[2]) tokens.push({ length: 1, text: match[2] });
+    tokens.push({ length: Number(match[1]), text: match[2] });
   }
   return tokens;
 };

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -9,7 +9,7 @@
  * 额外支持 XML 包裹：`LyricContent="..."` 属性 或 `<![CDATA[...]]>` 段
  */
 
-import type { LyricLine, LyricWord } from "@shared/types/lyrics";
+import type { LyricLine, LyricWord, LyricSpan } from "@shared/types/lyrics";
 import { detectBackgroundLine, splitTrailingBackground } from "./bg";
 
 /** 行头：[起始毫秒, 时长毫秒] */
@@ -17,6 +17,56 @@ const LINE_HEADER_RE = /^\[(\d+),(\d+)\]/;
 
 /** 时间标记开头：`(` 紧跟数字 */
 const TIMING_RE = /\((\d+),(\d+)\)/;
+const KANJI_RE = /[\p{Unified_Ideograph}\u3400-\u4dbf]/u;
+
+interface KanaToken {
+  length: number;
+  text: string;
+}
+
+const parseKanaTokens = (value: string): KanaToken[] => {
+  const clean = value.replace(/\(\d+,\d+\)/g, "");
+  const tokens: KanaToken[] = [];
+  const re = /(\d+)(\D*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(clean))) {
+    const digits = match[1];
+    for (let i = 0; i < digits.length - (digits.length === 1 ? 1 : 0); i++) {
+      tokens.push({ length: Number(digits[i]), text: "" });
+    }
+    if (digits.length === 1) tokens.push({ length: Number(digits[0]), text: match[2] });
+    else if (match[2]) tokens.push({ length: 1, text: match[2] });
+  }
+  return tokens;
+};
+
+const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
+  let tokenIndex = 0;
+  let remaining = 0;
+  let reading = "";
+  for (const line of lines) {
+    for (const word of line.words) {
+      const chars = [...word.word];
+      const kanjiCount = chars.filter((char) => KANJI_RE.test(char)).length;
+      if (!kanjiCount) continue;
+      const ruby: LyricSpan[] = [];
+      for (const char of chars) {
+        if (!KANJI_RE.test(char)) continue;
+        if (remaining === 0) {
+          const token = tokens[tokenIndex++];
+          if (!token) break;
+          remaining = token.length;
+          reading = token.text;
+        }
+        remaining--;
+        if (remaining === 0 && reading) {
+          ruby.push({ startTime: word.startTime, endTime: word.endTime, word: reading });
+        }
+      }
+      if (ruby.some((item) => item.word)) word.ruby = ruby;
+    }
+  }
+};
 
 /**
  * 逐字符解析单行 QRC 字级歌词
@@ -84,6 +134,8 @@ const extractFromXml = (text: string): string => {
 /** 解析 QRC 歌词 */
 export const parseQRC = (text: string, detectBackground = true): LyricLine[] => {
   const content = extractFromXml(text);
+  const kanaLine = content.match(/^\[kana:([^\r\n]*)\]/m);
+  const kanaTokens = kanaLine ? parseKanaTokens(kanaLine[1]) : [];
   const lines: LyricLine[] = [];
 
   for (const raw of content.split("\n")) {
@@ -118,5 +170,6 @@ export const parseQRC = (text: string, detectBackground = true): LyricLine[] => 
     }
   }
 
+  applyKana(lines, kanaTokens);
   return lines;
 };

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -139,7 +139,7 @@ const extractFromXml = (text: string): string => {
 };
 
 /** 解析 QRC 歌词 */
-export const parseQRC = (text: string, detectBackground = true): LyricLine[] => {
+export const parseQRC = (text: string, detectBackground = true, showKana = true): LyricLine[] => {
   const content = extractFromXml(text);
   const kanaLine = content.match(/^\[kana:([^\r\n]*)\]/m);
   const kanaTokens = kanaLine ? parseKanaTokens(kanaLine[1]) : [];
@@ -177,6 +177,6 @@ export const parseQRC = (text: string, detectBackground = true): LyricLine[] => 
     }
   }
 
-  applyKana(lines, kanaTokens);
+  if (showKana) applyKana(lines, kanaTokens);
   return lines;
 };

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -9,7 +9,7 @@
  * 额外支持 XML 包裹：`LyricContent="..."` 属性 或 `<![CDATA[...]]>` 段
  */
 
-import type { LyricLine, LyricWord, LyricSpan } from "@shared/types/lyrics";
+import type { LyricLine, LyricWord } from "@shared/types/lyrics";
 import { detectBackgroundLine, splitTrailingBackground } from "./bg";
 
 /** 行头：[起始毫秒, 时长毫秒] */
@@ -68,7 +68,7 @@ const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
       }
 
       remaining -= Math.min(remaining, targetCount);
-      if (remaining === 0 && currentToken.text) {
+      if (remaining === 0 && currentToken?.text) {
         word.ruby = [{ startTime: word.startTime, endTime: word.endTime, word: currentToken.text }];
       }
     }

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -17,7 +17,9 @@ const LINE_HEADER_RE = /^\[(\d+),(\d+)\]/;
 
 /** 时间标记开头：`(` 紧跟数字 */
 const TIMING_RE = /\((\d+),(\d+)\)/;
-const KANJI_RE = /[\p{Unified_Ideograph}\u3400-\u4dbf]/u;
+/** 可注音字符：汉字、迭代符号、半角/全角数字及编号数字 */
+const RUBY_TARGET_RE =
+  /[\p{Unified_Ideograph}\u3400-\u4dbf\uf900-\ufaff\u3005\u3006\u30070-9０-９\u2160-\u217f\u2460-\u2473]/u;
 
 interface KanaToken {
   length: number;
@@ -42,11 +44,11 @@ const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
   for (const line of lines) {
     for (const word of line.words) {
       const chars = [...word.word];
-      const kanjiCount = chars.filter((char) => KANJI_RE.test(char)).length;
-      if (!kanjiCount) continue;
+      const targetCount = chars.filter((char) => RUBY_TARGET_RE.test(char)).length;
+      if (!targetCount) continue;
       const ruby: LyricSpan[] = [];
       for (const char of chars) {
-        if (!KANJI_RE.test(char)) continue;
+        if (!RUBY_TARGET_RE.test(char)) continue;
         if (remaining === 0) {
           const token = tokens[tokenIndex++];
           if (!token) break;

--- a/src/utils/lyric/parseQRC.ts
+++ b/src/utils/lyric/parseQRC.ts
@@ -24,15 +24,20 @@ const RUBY_TARGET_RE =
 interface KanaToken {
   length: number;
   text: string;
+  startTime?: number;
 }
 
 const parseKanaTokens = (value: string): KanaToken[] => {
-  const clean = value.replace(/\(\d+,\d+\)/g, "");
   const tokens: KanaToken[] = [];
-  const re = /(\d)(\D*)/g;
+  const re = /(\d)((?:[^\d(]|\(\d+,\d+\))*)/g;
   let match: RegExpExecArray | null;
-  while ((match = re.exec(clean))) {
-    tokens.push({ length: Number(match[1]), text: match[2] });
+  while ((match = re.exec(value))) {
+    const timing = match[2].match(/\((\d+),\d+\)/);
+    tokens.push({
+      length: Number(match[1]),
+      text: match[2].replace(/\(\d+,\d+\)/g, ""),
+      startTime: timing ? Number(timing[1]) : undefined,
+    });
   }
   return tokens;
 };
@@ -40,27 +45,32 @@ const parseKanaTokens = (value: string): KanaToken[] => {
 const applyKana = (lines: LyricLine[], tokens: KanaToken[]): void => {
   let tokenIndex = 0;
   let remaining = 0;
-  let reading = "";
+  let currentToken: KanaToken | null = null;
   for (const line of lines) {
     for (const word of line.words) {
       const chars = [...word.word];
       const targetCount = chars.filter((char) => RUBY_TARGET_RE.test(char)).length;
       if (!targetCount) continue;
-      const ruby: LyricSpan[] = [];
-      for (const char of chars) {
-        if (!RUBY_TARGET_RE.test(char)) continue;
-        if (remaining === 0) {
-          const token = tokens[tokenIndex++];
-          if (!token) break;
-          remaining = token.length;
-          reading = token.text;
-        }
-        remaining--;
-        if (remaining === 0 && reading) {
-          ruby.push({ startTime: word.startTime, endTime: word.endTime, word: reading });
-        }
+
+      const anchorIndex = tokens.findIndex(
+        (token, index) => index >= tokenIndex && token.startTime === word.startTime,
+      );
+      if (anchorIndex !== -1) {
+        tokenIndex = anchorIndex;
+        remaining = 0;
+        currentToken = null;
       }
-      if (ruby.some((item) => item.word)) word.ruby = ruby;
+
+      if (remaining <= 0) {
+        currentToken = tokens[tokenIndex++] ?? null;
+        if (!currentToken) break;
+        remaining = currentToken.length;
+      }
+
+      remaining -= Math.min(remaining, targetCount);
+      if (remaining === 0 && currentToken.text) {
+        word.ruby = [{ startTime: word.startTime, endTime: word.endTime, word: currentToken.text }];
+      }
     }
   }
 };


### PR DESCRIPTION

<img width="1847" height="1098" alt="1" src="https://github.com/user-attachments/assets/78af6b6a-6c95-40b9-b5eb-ba5a764c9628" />


## 改动类型

- [x] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

为 QRC 日文歌词增加振假名注音支持，并修复注音队列错位问题。

主要变更：

- 解析 QRC 中的 `[kana:...]` 注音数据。
- 解析前移除 kana 内嵌的时间戳，同时保留时间戳作为同步锚点。
- 支持全局 FIFO 注音队列，确保标题、歌手、作词、作曲等元数据行也正确消费 token。
- 支持连续空占位符，例如 `11111`。
- 支持汉字、全角/半角数字、`々`、`〇`、罗马数字和圆圈数字等注音目标字符。
- 将同一 QRC 时间块中的连续数字作为一个注音单元，避免 `31` 被错误消费两次。
- 增加时间戳锚点同步，修复英文段落中的占位符数量误差造成的后续错位。
- 播放页使用 `<ruby><rt>` 渲染振假名。
- 注音绑定发生在歌词排除之前，避免元数据过滤导致后续注音整体偏移。

## 关联 Issue

<!-- 如有关联，填 #编号；写 "Closes #编号" 可在合并时自动关闭对应 Issue -->

无

## 测试情况

已运行：

```text
pnpm exec vitest run src/utils/lyric/parse.spec.ts
```

结果：

```text
Test Files  1 passed
Tests       10 passed
```

覆盖内容包括：

- 连续 `1` 占位符解析
- kana 时间戳移除
- 全角数字注音
- `々` 迭代符号注音
- 同一时间块中的连续数字，例如 `31`
- 注音 token 与歌词 word 的 FIFO 对齐

`pnpm typecheck` 仍存在项目当前已有的 Vue 文件缺失错误，与本次改动无关。

## 截图 / 录屏

涉及播放页歌词 UI，建议补充一张包含日文振假名的播放页截图或录屏。

## 自查清单

- [x] 本 PR 只包含一个主要功能 / 修复，没有夹带无关改动
- [x] 已对改动进行测试和审阅，未提交未经验证的代码
- [ ] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [ ] 已向 `dev` 分支提交