### PR TITLE
fix: 修复灵动岛在 Linux Wayland 下不可见与置顶失效

### DIFF
--- a/docs/en/troubleshooting/wayland.md
+++ b/docs/en/troubleshooting/wayland.md
@@ -17,6 +17,7 @@ Exec=/opt/SPlayer-Next/SPlayer-Next --ozone-platform=x11 %U
 ```
 
 In KDE Plasma, the same change can be made by editing the application's desktop entry and replacing `%U` with `--ozone-platform=x11 %U`.
+
 > [!NOTE]
 >
 > Under Xwayland the Dynamic Island used to be completely invisible (the window was clipped to nothing). The issue is fixed in the latest version, so if you gave up on Xwayland because of that, please upgrade and retry. Under Xwayland, always-on-top, snap centering and absolute positioning all go through the X11 protocol and work normally.
@@ -28,14 +29,14 @@ In KDE Plasma, the same change can be made by editing the application's desktop 
 
 Wayland intentionally prevents applications from reading or setting global coordinates and applies stricter rules to transparent, borderless, always-on-top windows.
 
-| Feature                           | Possible behavior under Wayland                     |
-| --------------------------------- | --------------------------------------------------- |
-| Desktop lyrics / Dynamic Island   | Rendering errors, opaque background, wrong position |
-| Absolute positioning and snapping | Unavailable or inaccurate                           |
-| Always on top                     | Not possible on native Wayland; use window rules or Xwayland      |
-| Click-through                     | May not work                                        |
-| Global cursor hover detection     | Hidden/interactive behavior may be inaccurate       |
-| Global shortcuts                  | May fail to register                                |
+| Feature                           | Possible behavior under Wayland                              |
+| --------------------------------- | ------------------------------------------------------------ |
+| Desktop lyrics / Dynamic Island   | Rendering errors, opaque background, wrong position          |
+| Absolute positioning and snapping | Unavailable or inaccurate                                    |
+| Always on top                     | Not possible on native Wayland; use window rules or Xwayland |
+| Click-through                     | May not work                                                 |
+| Global cursor hover detection     | Hidden/interactive behavior may be inaccurate                |
+| Global shortcuts                  | May fail to register                                         |
 
 Behavior varies between GNOME Mutter, KDE KWin, wlroots-based compositors, and other environments.
 

--- a/docs/en/troubleshooting/wayland.md
+++ b/docs/en/troubleshooting/wayland.md
@@ -48,10 +48,11 @@ The Dynamic Island window uses the fixed title **`Dynamic Island`** and can be m
 
 > [!NOTE]
 >
-> Native Wayland does not let applications set absolute window coordinates, so the Island grows rightward from its fixed top-left corner as lyrics change (side-to-side jumping); snap centering cannot truly work on native Wayland. Two options:
+> Native Wayland does not let applications set absolute window coordinates, so the Island grows rightward from its fixed top-left corner as lyrics change (side-to-side jumping); snap centering cannot truly work on native Wayland. Three options:
 >
 > 1. Run under Xwayland (see above) — centering and always-on-top both work through the X11 protocol;
 > 2. In KWin, **force a fixed position / always-on-top** with the rule below so the compositor replaces the app's own positioning.
+> 3. Use the [KWin script](#dynamic-centering-with-a-kwin-script) below to center it dynamically, so it stays centered as the lyrics widen.
 
 Example KWin rule:
 
@@ -113,6 +114,86 @@ window-rule {
 If normal mouse dragging does not work, enable **Settings → External Lyrics → Desktop Lyrics → Use CSS dragging**. Otherwise, use the compositor shortcut, such as Meta + left mouse button in KWin or Alt + left mouse button in Mutter.
 
 Click-through while locked is a known issue; Xwayland may help.
+
+## Dynamic centering with a KWin script
+
+The window rule above is static — it fixes a position/size, but as the lyric text changes the Island still grows rightward from its fixed left edge, so it cannot stay centered. To center it dynamically, use a **KWin script** (it runs inside the compositor and can read/write window geometry, bypassing the client-side Wayland restriction).
+
+The script below keeps the Dynamic Island horizontally centered and flush with the top of the work area:
+
+```js
+// Horizontal centering; vertical flush with work-area top (below the panel). Width/height are left to the app.
+const WM_CLASS = "top.imsyy.splayer_next";
+const ISLAND_TITLE = "Dynamic Island";
+const TOP_OFFSET = 0; // extra offset below the work-area top, increase if you want a gap
+
+function isIsland(w) {
+  return (
+    (w.resourceClass === WM_CLASS || w.resourceName === WM_CLASS) && w.caption === ISLAND_TITLE
+  );
+}
+
+function centerIsland(w) {
+  const area = workspace.clientArea(KWin.MaximizeArea, w); // work area excluding panels
+  const fb = w.frameGeometry;
+  if (fb.width <= 0 || fb.height <= 0) return;
+
+  const x = Math.round(area.x + (area.width - fb.width) / 2);
+  const y = area.y + TOP_OFFSET;
+  // only write back if there is an offset, to avoid re-triggering frameGeometryChanged
+  if (Math.abs(fb.x - x) > 1 || Math.abs(fb.y - y) > 1) {
+    w.frameGeometry = { x: x, y: y, width: fb.width, height: fb.height };
+  }
+}
+
+function attach(w) {
+  if (!isIsland(w) || w._splayerCentered) return;
+  w._splayerCentered = true;
+  w.frameGeometryChanged.connect(() => centerIsland(w));
+  centerIsland(w);
+}
+
+workspace.windowList().forEach(attach); // existing windows
+workspace.windowAdded.connect(attach); // windows created later
+```
+
+Install the script as `~/.local/share/kwin/scripts/splayer-island-center/contents/code/main.js` and create `metadata.json` next to it:
+
+```json
+{
+  "KPlugin": {
+    "Id": "splayer-island-center",
+    "Name": "SPlayer Dynamic Island Center",
+    "Description": "Keep the SPlayer Dynamic Island centered on native Wayland",
+    "Authors": [{ "Name": "expoli" }],
+    "License": "MIT",
+    "Version": "1.0"
+  },
+  "KPackageStructure": "KWin/Script"
+}
+```
+
+Then enable it under **System Settings → Window Management → KWin Scripts** (or log out and back in).
+
+> [!NOTE]
+>
+> Debugging gotchas found when writing this script:
+>
+> - `window.geometry` reads as `undefined` on native Wayland — use `window.frameGeometry` instead;
+> - `Qt.rect(...)` is not available in KWin 6 scripting — assign an object literal `{ x, y, width, height }`;
+> - guard the write with `Math.abs(...) > 1` so the set does not re-trigger `frameGeometryChanged` (feedback loop);
+> - match on `resourceClass` **and** the caption — the main window uses the same `top.imsyy.splayer_next` class.
+
+Reload without logging out after editing the script:
+
+```bash
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript splayer-island-center
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript \
+  ~/.local/share/kwin/scripts/splayer-island-center/contents/code/main.js splayer-island-center
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start
+```
+
+> This only works on KDE / KWin; GNOME needs a Mutter extension to do the same dynamic centering.
 
 ## Global shortcuts
 

--- a/docs/en/troubleshooting/wayland.md
+++ b/docs/en/troubleshooting/wayland.md
@@ -17,6 +17,9 @@ Exec=/opt/SPlayer-Next/SPlayer-Next --ozone-platform=x11 %U
 ```
 
 In KDE Plasma, the same change can be made by editing the application's desktop entry and replacing `%U` with `--ozone-platform=x11 %U`.
+> [!NOTE]
+>
+> Under Xwayland the Dynamic Island used to be completely invisible (the window was clipped to nothing). The issue is fixed in the latest version, so if you gave up on Xwayland because of that, please upgrade and retry. Under Xwayland, always-on-top, snap centering and absolute positioning all go through the X11 protocol and work normally.
 
 > [!IMPORTANT]
 > Xwayland may not fix global shortcuts and can make them unavailable because it cannot listen to native Wayland input or register through XDG Desktop Portal. KDE users can adjust **System Settings → Application Permissions → Legacy X11 App Support** if they accept the security trade-off.
@@ -29,7 +32,7 @@ Wayland intentionally prevents applications from reading or setting global coord
 | --------------------------------- | --------------------------------------------------- |
 | Desktop lyrics / Dynamic Island   | Rendering errors, opaque background, wrong position |
 | Absolute positioning and snapping | Unavailable or inaccurate                           |
-| Always on top                     | Limited compositor support                          |
+| Always on top                     | Not possible on native Wayland; use window rules or Xwayland      |
 | Click-through                     | May not work                                        |
 | Global cursor hover detection     | Hidden/interactive behavior may be inaccurate       |
 | Global shortcuts                  | May fail to register                                |
@@ -40,7 +43,18 @@ Behavior varies between GNOME Mutter, KDE KWin, wlroots-based compositors, and o
 
 The desktop lyric window has the fixed title `SPlayer-Next - Desktop Lyric`. In KWin, create a rule matching window class `top.imsyy.splayer_next` and this exact title. You can force Always on Top, Overlay layer, All Desktops, and skip taskbar/pager/switcher behavior.
 
+The Dynamic Island window uses the fixed title **`Dynamic Island`** and can be matched the same way.
+
+> [!NOTE]
+>
+> Native Wayland does not let applications set absolute window coordinates, so the Island grows rightward from its fixed top-left corner as lyrics change (side-to-side jumping); snap centering cannot truly work on native Wayland. Two options:
+>
+> 1. Run under Xwayland (see above) — centering and always-on-top both work through the X11 protocol;
+> 2. In KWin, **force a fixed position / always-on-top** with the rule below so the compositor replaces the app's own positioning.
+
 Example KWin rule:
+
+> Save any rule snippet below as a `*.kwinrule` file (UTF-8) and import it via **System Settings → Window Management → Window Rules → Import…**, or append it to `~/.config/kwinrulesrc`.
 
 ```ini
 [SPlayer Next Desktop Lyric]
@@ -58,6 +72,29 @@ skipswitcherrule=2
 skiptaskbar=true
 skiptaskbarrule=2
 title=SPlayer-Next - Desktop Lyric
+titlematch=1
+wmclass=top.imsyy.splayer_next
+wmclassmatch=1
+```
+
+Dynamic Island (set **Position** separately for your resolution):
+
+```ini
+[SPlayer Next Dynamic Island]
+Description=SPlayer Next Dynamic Island
+above=true
+aboverule=2
+desktops=\0
+desktopsrule=2
+layer=overlay
+layerrule=2
+skippager=true
+skippagerrule=2
+skipswitcher=true
+skipswitcherrule=2
+skiptaskbar=true
+skiptaskbarrule=2
+title=Dynamic Island
 titlematch=1
 wmclass=top.imsyy.splayer_next
 wmclassmatch=1

--- a/docs/troubleshooting/wayland.md
+++ b/docs/troubleshooting/wayland.md
@@ -30,6 +30,10 @@ pnpm dev -- --ozone-platform=x11
    ```
 4. 保存退出。
 
+> [!NOTE]
+>
+> 灵动岛在 Xwayland 下曾经完全无法显示（窗口被裁切成空白），该问题已修复。若你之前因为灵动岛显示异常而放弃 Xwayland，请升级到最新版本后再试。Xwayland 下窗口置顶、吸附居中、绝对定位均走 X11 协议，可正常工作。
+
 > [!IMPORTANT]
 >
 > 使用 Xwayland 可能并不能解决全局快捷键的问题，反而可能导致全局快捷键失效。因为 Xwayland 无法监听原生 Wayland 的按键事件，也无法通过 XDG Desktop Portal 注册全局快捷键。
@@ -44,7 +48,7 @@ Wayland 出于安全考虑，不允许应用读取 / 设置全局屏幕坐标，
 | ---------------------------------------- | ------------------------------------------------- |
 | 桌面歌词 / 灵动岛（无边框 + 透明悬浮窗） | 可能渲染异常、出现不透明背景，或定位错位          |
 | 窗口绝对定位（拖拽、吸附、记忆位置）     | Wayland 不允许应用设置绝对坐标，可能失效或错位    |
-| 窗口置顶（always-on-top）                | 支持有限，悬浮窗可能无法保持置顶                  |
+| 窗口置顶（always-on-top）                | 原生 Wayland 下无法生效，需窗口规则或 Xwayland    |
 | 鼠标穿透（click-through）                | 可能不生效                                        |
 | 悬停判定（全局光标位置）                 | Wayland 限制读取全局光标，悬停隐藏 / 交互可能不准 |
 | 全局快捷键                               | Wayland 下可能无法注册全局快捷键                  |
@@ -69,6 +73,15 @@ Wayland 出于安全考虑，不允许应用读取 / 设置全局屏幕坐标，
 
 其它 DE/WM 也可参考此配置方法自行配置。
 
+灵动岛窗口的标题固定为 **`Dynamic Island`**，可按标题同理配置窗口规则。
+
+> [!NOTE]
+>
+> 原生 Wayland 不允许应用设置窗口绝对坐标，因此歌词长度变化时灵动岛会从窗口左上角向右伸缩（左右弹跳），吸附居中在原生 Wayland 下无法真正生效。两种解决办法：
+>
+> 1. 以 Xwayland 运行（见上），居中与置顶均走 X11 协议，可正常工作；
+> 2. 在 KWin 中用下面规则**强制固定位置 / 置顶**，让合成器代替应用完成定位与置顶。
+
 这里也提供了一些可直接导入的规则。欢迎 PR 补充其它环境或更好的配置
 
 <details>
@@ -76,6 +89,8 @@ Wayland 出于安全考虑，不允许应用读取 / 设置全局屏幕坐标，
 <summary>可直接导入的规则</summary>
 
 KWin 规则
+
+> 将下面任一规则片段保存为 `*.kwinrule` 文件（UTF-8），在 **系统设置 → 窗口管理 → 窗口规则** 里点 **导入…** 选择该文件即可；也可手工追加到 `~/.config/kwinrulesrc`。
 
 > 编者用的规则，我觉得挺好用的
 
@@ -95,6 +110,29 @@ skipswitcherrule=2
 skiptaskbar=true
 skiptaskbarrule=2
 title=SPlayer-Next - Desktop Lyric
+titlematch=1
+wmclass=top.imsyy.splayer_next
+wmclassmatch=1
+```
+
+灵动岛（KWin 规则需按实际分辨率另行设置 **位置**）
+
+```ini
+[SPlayer Next 灵动岛]
+Description=SPlayer Next 灵动岛
+above=true
+aboverule=2
+desktops=\0
+desktopsrule=2
+layer=overlay
+layerrule=2
+skippager=true
+skippagerrule=2
+skipswitcher=true
+skipswitcherrule=2
+skiptaskbar=true
+skiptaskbarrule=2
+title=Dynamic Island
 titlematch=1
 wmclass=top.imsyy.splayer_next
 wmclassmatch=1

--- a/docs/troubleshooting/wayland.md
+++ b/docs/troubleshooting/wayland.md
@@ -77,10 +77,11 @@ Wayland 出于安全考虑，不允许应用读取 / 设置全局屏幕坐标，
 
 > [!NOTE]
 >
-> 原生 Wayland 不允许应用设置窗口绝对坐标，因此歌词长度变化时灵动岛会从窗口左上角向右伸缩（左右弹跳），吸附居中在原生 Wayland 下无法真正生效。两种解决办法：
+> 原生 Wayland 不允许应用设置窗口绝对坐标，因此歌词长度变化时灵动岛会从窗口左上角向右伸缩（左右弹跳），吸附居中在原生 Wayland 下无法真正生效。三种解决办法：
 >
 > 1. 以 Xwayland 运行（见上），居中与置顶均走 X11 协议，可正常工作；
 > 2. 在 KWin 中用下面规则**强制固定位置 / 置顶**，让合成器代替应用完成定位与置顶。
+> 3. 用 **KWin 脚本**动态居中（见下文「用 KWin 脚本实现灵动岛动态居中」），歌词变宽时也始终居中。
 
 这里也提供了一些可直接导入的规则。欢迎 PR 补充其它环境或更好的配置
 
@@ -156,6 +157,86 @@ window-rule {
 拖动时直接按鼠标左键无法拖动。此时可以尝试打开 SPlayer-Next 的 **全局设置 → 外部歌词 → 桌面歌词 → 使用 CSS 拖拽** 功能。若还是无法拖动，请使用 WM 的窗口拖动快捷键（如 KWin 默认的 <kbd>Meta</kbd>+<kbd>鼠标左键</kbd> 或 Mutter 默认的 <kbd>Alt</kbd>+<kbd>鼠标左键</kbd>）
 
 锁定时鼠标穿透不生效是已知问题。可以尝试[使用 Xwayland](#使用-xwayland)
+
+## 用 KWin 脚本实现灵动岛动态居中
+
+上面的 KWin 窗口规则是**静态**的——只能固定一个位置/大小，歌词文本一变，灵动岛仍会从固定左边缘向右伸缩，无法保持居中。要**动态居中**，需要借助 **KWin 脚本**（它运行在合成器进程内，可读写窗口几何，不受客户端侧 Wayland 协议限制）。
+
+下面脚本让灵动岛在原生 Wayland 下保持水平居中，并贴合工作区顶部：
+
+```js
+// 水平居中；垂直贴合工作区顶部（panel 下方）。宽高由应用自行决定，这里不改。
+const WM_CLASS = "top.imsyy.splayer_next";
+const ISLAND_TITLE = "Dynamic Island";
+const TOP_OFFSET = 0; // 距工作区顶部的额外间距，需要留空就调大
+
+function isIsland(w) {
+  return (
+    (w.resourceClass === WM_CLASS || w.resourceName === WM_CLASS) && w.caption === ISLAND_TITLE
+  );
+}
+
+function centerIsland(w) {
+  const area = workspace.clientArea(KWin.MaximizeArea, w); // 排除面板的可用工作区
+  const fb = w.frameGeometry;
+  if (fb.width <= 0 || fb.height <= 0) return;
+
+  const x = Math.round(area.x + (area.width - fb.width) / 2);
+  const y = area.y + TOP_OFFSET;
+  // 有偏移才写回，避免把自己设的几何再次触发 frameGeometryChanged 形成循环
+  if (Math.abs(fb.x - x) > 1 || Math.abs(fb.y - y) > 1) {
+    w.frameGeometry = { x: x, y: y, width: fb.width, height: fb.height };
+  }
+}
+
+function attach(w) {
+  if (!isIsland(w) || w._splayerCentered) return;
+  w._splayerCentered = true;
+  w.frameGeometryChanged.connect(() => centerIsland(w));
+  centerIsland(w);
+}
+
+workspace.windowList().forEach(attach); // 已存在的窗口
+workspace.windowAdded.connect(attach); // 之后新建的灵动岛窗口
+```
+
+将脚本保存为 `~/.local/share/kwin/scripts/splayer-island-center/contents/code/main.js`，并在同目录创建 `metadata.json`：
+
+```json
+{
+  "KPlugin": {
+    "Id": "splayer-island-center",
+    "Name": "SPlayer Dynamic Island Center",
+    "Description": "Keep the SPlayer Dynamic Island centered on native Wayland",
+    "Authors": [{ "Name": "expoli" }],
+    "License": "MIT",
+    "Version": "1.0"
+  },
+  "KPackageStructure": "KWin/Script"
+}
+```
+
+然后在 **系统设置 → 窗口管理 → KWin 脚本** 中勾选启用（或注销后重新登录）。
+
+> [!NOTE]
+>
+> 编写该脚本时踩到的坑：
+>
+> - `window.geometry` 在原生 Wayland 下读取为 `undefined`，改用 `window.frameGeometry`；
+> - KWin 6 脚本里没有 `Qt.rect(...)`，要用对象字面量 `{ x, y, width, height }` 赋值；
+> - 回写前用 `Math.abs(...) > 1` 判断，否则设置的几何会再次触发 `frameGeometryChanged` 形成循环；
+> - 窗口匹配要同时用 `resourceClass` 与标题（主窗口也是 `top.imsyy.splayer_next`，只靠 wmclass 会误匹配）。
+
+改完脚本不需要注销，可直接热重载：
+
+```bash
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript splayer-island-center
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript \
+  ~/.local/share/kwin/scripts/splayer-island-center/contents/code/main.js splayer-island-center
+qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start
+```
+
+> 该方案仅适用于 KDE / KWin；GNOME 需借助 Mutter 扩展才能实现同样的动态居中。
 
 ## 全局快捷键
 

--- a/electron/main/window/dynamicIsland.ts
+++ b/electron/main/window/dynamicIsland.ts
@@ -4,7 +4,7 @@ import { is } from "@electron-toolkit/utils";
 import { createWindow } from "./create";
 import { store } from "@main/store";
 import { broadcast } from "@main/utils/broadcast";
-import { isMac } from "@main/utils/config";
+import { isLinux, isMac } from "@main/utils/config";
 import { setTrayDynamicIsland } from "@main/services/tray";
 import { isAppQuitting } from "@main/utils/lifecycle";
 import { DYNAMIC_ISLAND_BASE_HEIGHT } from "@shared/defaults/settings";
@@ -360,7 +360,9 @@ export const applyDynamicIslandWidth = (width: number): void => {
 
 const updateDynamicIslandShape = (): void => {
   const win = getDynamicIslandWindow();
-  if (!win || isMac) return;
+  // Linux（含 XWayland）跳过 setShape：X11 Shape 扩展在 XWayland 合成器下会把整个窗口
+  // 渲染 surface 丢弃，导致灵动岛在桌面上完全不可见（issue #75）；原生 Wayland 同样无 shape 概念
+  if (!win || isMac || isLinux) return;
   if (activeShapeWidth === null) {
     win.setShape([]);
     return;


### PR DESCRIPTION
## 问题

关联 issue #75：Ubuntu 26.04 Wayland（KDE）下灵动岛默认置顶无法生效；Xwayland（`--ozone-platform=x11`）下灵动岛完全不可见；原生 Wayland 下歌词长度变化时灵动岛左右弹跳。

## 根因

1. **Xwayland 下不可见**：commit `4e37ece`（灵动岛歌词切换动画）引入的 `win.setShape()` 走 X11 Shape 扩展，XWayland 合成器对 Shape 扩展支持有问题，调用后整窗渲染 surface 被丢弃，窗口在任务栏可见但画面完全不可见（社区已逐项回退定位到 `setShape` 并在 fork 验证）。
2. **置顶 / 居中**：Wayland 协议不允许客户端控制窗口 z-order 与绝对坐标（[electron/electron#50403](https://github.com/electron/electron/issues/50403) 官方确认），原生 Wayland 下 `setAlwaysOnTop` / `setBounds` 均为 no-op，只能靠合成器窗口规则、KWin 脚本或 Xwayland。

## 改动

- **`electron/main/window/dynamicIsland.ts`**：Linux（含 XWayland）跳过 `setShape`（与 macOS 同理；`activeShapeWidth` 仍用于悬停命中判定，仅跳过视觉裁切）。恢复 Xwayland 下灵动岛显示，使官方文档推荐的 `--ozone-platform=x11` 方案可用（置顶、吸附居中、绝对定位均走 X11 协议）。
- **`docs/troubleshooting/wayland.md` / `docs/en/troubleshooting/wayland.md`**：
  - 说明灵动岛在 Xwayland 下不可见问题已修复；
  - 说明原生 Wayland 下弹跳的原因（应用无法设置绝对坐标，窗口从固定左上角向右伸缩）与解法；
  - 新增「Dynamic Island」的 KWin 窗口规则（强制置顶、叠加图层、跳过任务栏/分页器/切换器等），KDE 用户可自动化"手动置顶"；
  - 新增 **KWin 脚本动态居中方案**：原生 Wayland 下让灵动岛始终水平居中、贴合工作区顶部，含安装/启用/热重载步骤与调试要点，弥补窗口规则只能静态定位、无法随歌词宽度变化而居中的不足（仅限 KDE/KWin）。

## 其他说明

- CI 已通过（含一次英文文档的 Prettier 格式修正）。
- 原生 Wayland 下置顶与居中属协议限制，应用侧无法直接设置坐标；已通过 **KWin 脚本** 提供动态居中方案（仅 KDE/KWin），GNOME 用户建议以 Xwayland 运行。

Fixes #75
