### PR TITLE
feat: 完善本地 TTML 歌词匹配机制（支持专辑消歧与三档匹配强度）

### DIFF
--- a/electron/main/apis/common/lyric/utils.ts
+++ b/electron/main/apis/common/lyric/utils.ts
@@ -46,7 +46,7 @@ export const buildLyricSearchKeyword = (track: Track): string =>
     .join(" ");
 
 /** 歌手是否有可用交集 */
-const artistMatches = (
+export const artistMatches = (
   candidateArtist: string | undefined | null,
   trackArtists: readonly string[],
 ): { exact: boolean; contains: boolean } => {

--- a/electron/main/apis/common/lyric/utils.ts
+++ b/electron/main/apis/common/lyric/utils.ts
@@ -24,7 +24,7 @@ export const normalize = (text: string | undefined | null): string => {
 };
 
 /** 双向 includes 命中 */
-const bothContains = (left: string, right: string): boolean =>
+export const bothContains = (left: string, right: string): boolean =>
   left.length > 0 && right.length > 0 && (left.includes(right) || right.includes(left));
 
 /** 拆分候选歌手文本 */

--- a/electron/main/services/localLyricRepo.ts
+++ b/electron/main/services/localLyricRepo.ts
@@ -15,14 +15,15 @@ import { readdir, stat } from "node:fs/promises";
 import { join, extname } from "node:path";
 import { readFileAutoEncoding } from "@main/utils/encoding";
 import { store } from "@main/store";
-import { normalize } from "@main/apis/common/lyric/utils";
+import { normalize, normalizeTrackArtists, artistMatches } from "@main/apis/common/lyric/utils";
 import { buildFingerprint, getMatchedId } from "@main/database/lyricMatchCache";
 import { coreLog } from "@main/utils/logger";
 import type { Track } from "@shared/types/player";
+import type { LocalLyricMatchLevel } from "@shared/types/settings";
 
-/** 同名候选：艺术家仅作区分，不作硬门槛 */
+/** 同名候选 */
 interface NameCandidate {
-  /** 归一化首艺术家，缺失为空串 */
+  /** 候选艺术家原始文本，供拆分比对 */
   artist: string;
   file: string;
 }
@@ -98,7 +99,7 @@ const buildIndex = async (dir: string): Promise<RepoIndex> => {
     if (meta.qqId && !index.byQq.has(meta.qqId)) index.byQq.set(meta.qqId, file);
     if (meta.name) {
       const titleKey = normalize(meta.name);
-      const candidate: NameCandidate = { artist: normalize(meta.artist ?? ""), file };
+      const candidate: NameCandidate = { artist: meta.artist ?? "", file };
       const list = index.byTitle.get(titleKey);
       if (list) list.push(candidate);
       else index.byTitle.set(titleKey, [candidate]);
@@ -146,21 +147,58 @@ const tryRead = async (file: string | undefined): Promise<string | null> => {
 };
 
 /**
- * 同名候选里按艺术家挑最匹配的；只有一条或无法用艺术家区分时取第一条
- * @param candidates - 同一标题下的候选
- * @param wantArtist - 归一化的目标首艺术家
- * @returns 命中文件路径
+ * 根据匹配强度从同名候选列表中挑选最匹配的文件
+ * @param candidates - 同一标题下的候选列表
+ * @param track - 目标歌曲
+ * @param level - 匹配强度 (strict | standard | loose)
+ * @returns 命中文件路径，未命中返回 null
  */
-const pickByArtist = (candidates: NameCandidate[], wantArtist: string): string => {
-  if (candidates.length === 1 || !wantArtist) return candidates[0].file;
-  const exact = candidates.find((candidate) => candidate.artist === wantArtist);
+const pickCandidate = (
+  candidates: NameCandidate[],
+  track: Track,
+  level: LocalLyricMatchLevel,
+): string | null => {
+  const trackArtists = normalizeTrackArtists(track);
+
+  // 宽松模式：保持原有容错，同名单个直接返回；多个优先匹配，无匹配兜底首个
+  if (level === "loose") {
+    if (candidates.length === 1 || trackArtists.length === 0) return candidates[0].file;
+    const exact = candidates.find(
+      (candidate) => artistMatches(candidate.artist, trackArtists).exact,
+    );
+    if (exact) return exact.file;
+    const partial = candidates.find(
+      (candidate) => artistMatches(candidate.artist, trackArtists).contains,
+    );
+    return (partial ?? candidates[0]).file;
+  }
+
+  // 严格模式：必须歌曲与候选均有艺术家，且完全严格一致
+  if (level === "strict") {
+    if (trackArtists.length === 0) return null;
+    const exact = candidates.find(
+      (candidate) => artistMatches(candidate.artist, trackArtists).exact,
+    );
+    return exact ? exact.file : null;
+  }
+
+  // 标准模式 (standard，默认)：优先艺术家完全一致
+  const exact = candidates.find((candidate) => artistMatches(candidate.artist, trackArtists).exact);
   if (exact) return exact.file;
+
+  // 其次子串相互包含（如合唱歌手、feat 等）
   const partial = candidates.find(
-    (candidate) =>
-      candidate.artist &&
-      (candidate.artist.includes(wantArtist) || wantArtist.includes(candidate.artist)),
+    (candidate) => artistMatches(candidate.artist, trackArtists).contains,
   );
-  return (partial ?? candidates[0]).file;
+  if (partial) return partial.file;
+
+  // 元数据缺失容错：目标歌曲无艺术家信息时允许取同名首个；候选本身无艺术家信息也允许命中
+  if (trackArtists.length === 0) return candidates[0].file;
+  const emptyArtistCandidate = candidates.find((candidate) => !candidate.artist.trim());
+  if (emptyArtistCandidate) return emptyArtistCandidate.file;
+
+  // 双方均有艺术家但完全互不相干（如不同歌手同名曲）：拒绝盲目兜底
+  return null;
 };
 
 /**
@@ -197,6 +235,9 @@ export const matchLocalTTML = async (track: Track): Promise<string | null> => {
   if (!store.get("localLyric.enableLocalTTMLOverride")) return null;
   const index = await getIndex();
   if (!index) return null;
+
+  const matchLevel = (store.get("localLyric.matchLevel") as LocalLyricMatchLevel) || "standard";
+
   // track 自带平台 id 精确命中（在线歌曲）
   if (track.source === "netease") {
     const hit = await tryRead(index.byNcm.get(track.id));
@@ -209,10 +250,14 @@ export const matchLocalTTML = async (track: Track): Promise<string | null> => {
       if (hit) return hit;
     }
   }
-  // 标题命中；同名多条时再用艺术家软性区分
+  // 标题命中：按匹配强度筛选候选
   const candidates = index.byTitle.get(normalize(track.title));
   if (candidates && candidates.length > 0) {
-    return tryRead(pickByArtist(candidates, normalize(track.artists[0]?.name ?? "")));
+    const picked = pickCandidate(candidates, track, matchLevel);
+    if (picked) {
+      const hit = await tryRead(picked);
+      if (hit) return hit;
+    }
   }
   // 兜底：平台 id 回查
   return matchByCachedId(track, index);

--- a/electron/main/services/localLyricRepo.ts
+++ b/electron/main/services/localLyricRepo.ts
@@ -15,7 +15,12 @@ import { readdir, stat } from "node:fs/promises";
 import { join, extname } from "node:path";
 import { readFileAutoEncoding } from "@main/utils/encoding";
 import { store } from "@main/store";
-import { normalize, normalizeTrackArtists, artistMatches } from "@main/apis/common/lyric/utils";
+import {
+  normalize,
+  normalizeTrackArtists,
+  artistMatches,
+  bothContains,
+} from "@main/apis/common/lyric/utils";
 import { buildFingerprint, getMatchedId } from "@main/database/lyricMatchCache";
 import { coreLog } from "@main/utils/logger";
 import type { Track } from "@shared/types/player";
@@ -25,6 +30,8 @@ import type { LocalLyricMatchLevel } from "@shared/types/settings";
 interface NameCandidate {
   /** 候选艺术家原始文本，供拆分比对 */
   artist: string;
+  /** 候选专辑原始文本，供比对 */
+  album: string;
   file: string;
 }
 
@@ -47,17 +54,20 @@ let building: Promise<RepoIndex | null> | null = null;
 /** 从 TTML 文本头部提取 AMLL 元信息 */
 const extractMeta = (
   text: string,
-): { name?: string; artist?: string; ncmId?: string; qqId?: string } => {
+): { name?: string; artist?: string; album?: string; ncmId?: string; qqId?: string } => {
   const bodyAt = text.indexOf("<body");
   const head = bodyAt > 0 ? text.slice(0, bodyAt) : text.slice(0, 8000);
-  const meta: { name?: string; artist?: string; ncmId?: string; qqId?: string } = {};
+  const meta: { name?: string; artist?: string; album?: string; ncmId?: string; qqId?: string } =
+    {};
   for (const tag of head.matchAll(/<amll:meta\b[^>]*>/gi)) {
     const key = tag[0].match(/\bkey="([^"]*)"/)?.[1];
     const value = tag[0].match(/\bvalue="([^"]*)"/)?.[1];
     if (!key || !value) continue;
     if (key === "musicName" && !meta.name) meta.name = value;
     else if (key === "artists" && !meta.artist) meta.artist = value;
-    else if (key === "ncmMusicId" && !meta.ncmId) meta.ncmId = value;
+    else if (key === "album" || key === "albumName" || key === "albumTitle") {
+      meta.album = meta.album ? `${meta.album} / ${value}` : value;
+    } else if (key === "ncmMusicId" && !meta.ncmId) meta.ncmId = value;
     else if (key === "qqMusicId" && !meta.qqId) meta.qqId = value;
   }
   return meta;
@@ -99,7 +109,11 @@ const buildIndex = async (dir: string): Promise<RepoIndex> => {
     if (meta.qqId && !index.byQq.has(meta.qqId)) index.byQq.set(meta.qqId, file);
     if (meta.name) {
       const titleKey = normalize(meta.name);
-      const candidate: NameCandidate = { artist: meta.artist ?? "", file };
+      const candidate: NameCandidate = {
+        artist: meta.artist ?? "",
+        album: meta.album ?? "",
+        file,
+      };
       const list = index.byTitle.get(titleKey);
       if (list) list.push(candidate);
       else index.byTitle.set(titleKey, [candidate]);
@@ -159,46 +173,99 @@ const pickCandidate = (
   level: LocalLyricMatchLevel,
 ): string | null => {
   const trackArtists = normalizeTrackArtists(track);
+  const trackAlbum = normalize(track.album?.name);
 
-  // 宽松模式：保持原有容错，同名单个直接返回；多个优先匹配，无匹配兜底首个
+  // 宽松模式：保持原有容错，多候选时按艺术家和专辑打分挑最优；都无匹配兜底首个
   if (level === "loose") {
     if (candidates.length === 1 || trackArtists.length === 0) return candidates[0].file;
-    const exact = candidates.find(
-      (candidate) => artistMatches(candidate.artist, trackArtists).exact,
-    );
-    if (exact) return exact.file;
-    const partial = candidates.find(
-      (candidate) => artistMatches(candidate.artist, trackArtists).contains,
-    );
-    return (partial ?? candidates[0]).file;
+    let best = candidates[0];
+    let bestScore = -1;
+    for (const candidate of candidates) {
+      let score = 0;
+      const artist = artistMatches(candidate.artist, trackArtists);
+      if (artist.exact) score += 100;
+      else if (artist.contains) score += 50;
+
+      const candAlbum = normalize(candidate.album);
+      if (trackAlbum && candAlbum) {
+        if (candAlbum === trackAlbum) score += 20;
+        else if (bothContains(candAlbum, trackAlbum)) score += 10;
+      }
+      if (score > bestScore) {
+        bestScore = score;
+        best = candidate;
+      }
+    }
+    return best.file;
   }
 
-  // 严格模式：必须歌曲与候选均有艺术家，且完全严格一致
+  // 严格模式：必须歌曲与候选均有艺术家且严格一致，若双方均有专辑则专辑也必须一致
   if (level === "strict") {
     if (trackArtists.length === 0) return null;
-    const exact = candidates.find(
-      (candidate) => artistMatches(candidate.artist, trackArtists).exact,
-    );
-    return exact ? exact.file : null;
+    let best: NameCandidate | null = null;
+    let bestScore = -1;
+
+    for (const candidate of candidates) {
+      const artist = artistMatches(candidate.artist, trackArtists);
+      if (!artist.exact) continue;
+
+      const candAlbum = normalize(candidate.album);
+      let albumScore = 0;
+      if (trackAlbum && candAlbum) {
+        if (candAlbum === trackAlbum) {
+          albumScore = 20;
+        } else if (bothContains(candAlbum, trackAlbum)) {
+          albumScore = 10;
+        } else {
+          continue; // 专辑冲突，严格模式直接排除
+        }
+      }
+
+      const score = 100 + albumScore;
+      if (score > bestScore) {
+        bestScore = score;
+        best = candidate;
+      }
+    }
+    return best ? best.file : null;
   }
 
-  // 标准模式 (standard，默认)：优先艺术家完全一致
-  const exact = candidates.find((candidate) => artistMatches(candidate.artist, trackArtists).exact);
-  if (exact) return exact.file;
+  // 标准模式 (standard，默认)：必须艺术家匹配；多候选根据艺术家与专辑匹配度综合择优
+  let best: NameCandidate | null = null;
+  let bestScore = -1;
 
-  // 其次子串相互包含（如合唱歌手、feat 等）
-  const partial = candidates.find(
-    (candidate) => artistMatches(candidate.artist, trackArtists).contains,
-  );
-  if (partial) return partial.file;
+  for (const candidate of candidates) {
+    const artist = artistMatches(candidate.artist, trackArtists);
+    let score = 0;
 
-  // 元数据缺失容错：目标歌曲无艺术家信息时允许取同名首个；候选本身无艺术家信息也允许命中
-  if (trackArtists.length === 0) return candidates[0].file;
-  const emptyArtistCandidate = candidates.find((candidate) => !candidate.artist.trim());
-  if (emptyArtistCandidate) return emptyArtistCandidate.file;
+    if (trackArtists.length > 0) {
+      if (artist.exact) score = 100;
+      else if (artist.contains) score = 60;
+      else if (!candidate.artist.trim())
+        score = 20; // 候选缺少艺术家，容错
+      else continue; // 双方均有艺术家且不匹配，坚决拒绝兜底
+    } else {
+      score = 20; // 目标歌曲无艺术家，容错
+    }
 
-  // 双方均有艺术家但完全互不相干（如不同歌手同名曲）：拒绝盲目兜底
-  return null;
+    const candAlbum = normalize(candidate.album);
+    if (trackAlbum && candAlbum) {
+      if (candAlbum === trackAlbum) {
+        score += 30; // 专辑完全一致
+      } else if (bothContains(candAlbum, trackAlbum)) {
+        score += 15; // 专辑包含
+      } else {
+        score -= 10; // 专辑不同，降级避免抢占同名同专辑候选
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      best = candidate;
+    }
+  }
+
+  return best ? best.file : null;
 };
 
 /**

--- a/shared/defaults/settings.ts
+++ b/shared/defaults/settings.ts
@@ -101,6 +101,7 @@ export const defaultSystemConfig: SystemConfig = {
   localLyric: {
     enableLocalTTMLOverride: false,
     repoDir: "",
+    matchLevel: "standard",
   },
   cache: {
     dir: null,

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -314,12 +314,17 @@ export interface OnlineLyricSettings {
   amllDbServer: string;
 }
 
+/** 本地 TTML 歌词匹配强度 */
+export type LocalLyricMatchLevel = "strict" | "standard" | "loose";
+
 /** 本地歌词配置 */
 export interface LocalLyricSettings {
   /** 启用本地 TTML 歌词库：从指定目录按元信息匹配 .ttml，命中优先于在线源 */
   enableLocalTTMLOverride: boolean;
   /** 本地 TTML 歌词库目录 */
   repoDir: string;
+  /** 本地 TTML 匹配强度 */
+  matchLevel: LocalLyricMatchLevel;
 }
 
 /** 歌曲缓存配置 */

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1983,6 +1983,13 @@
       "clear": "Clear",
       "unset": "Not set"
     },
+    "localLyricMatchLevel": {
+      "label": "Matching Strictness",
+      "description": "Control how strictly local TTML files are matched against the current song",
+      "strict": "Strict (Platform ID match, or exact title and artist match)",
+      "standard": "Standard (Recommended, exact title with matched or contained artist)",
+      "loose": "Loose (Title match only, may mismatch different songs with the same title)"
+    },
     "fileCacheManager": {
       "label": "Cache Manager",
       "description": "Inspect cache usage and clear it"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1986,8 +1986,8 @@
     "localLyricMatchLevel": {
       "label": "Matching Strictness",
       "description": "Control how strictly local TTML files are matched against the current song",
-      "strict": "Strict (Platform ID match, or exact title and artist match)",
-      "standard": "Standard (Recommended, exact title with matched or contained artist)",
+      "strict": "Strict (Platform ID match, or exact title and artist with matched album)",
+      "standard": "Standard (Recommended, matched artist and prioritized album)",
       "loose": "Loose (Title match only, may mismatch different songs with the same title)"
     },
     "fileCacheManager": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1971,6 +1971,13 @@
       "clear": "清除",
       "unset": "未设置目录"
     },
+    "localLyricMatchLevel": {
+      "label": "匹配强度",
+      "description": "控制本地 TTML 与当前歌曲的匹配严格程度",
+      "strict": "严格（平台 ID 匹配，或歌名与艺术家完全一致）",
+      "standard": "标准（推荐，歌名一致且艺术家匹配或包含）",
+      "loose": "宽松（仅歌名一致即可，同名不同曲可能误匹）"
+    },
     "fileCacheManager": {
       "label": "缓存管理",
       "description": "查看缓存占用并清理"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1974,8 +1974,8 @@
     "localLyricMatchLevel": {
       "label": "匹配强度",
       "description": "控制本地 TTML 与当前歌曲的匹配严格程度",
-      "strict": "严格（平台 ID 匹配，或歌名与艺术家完全一致）",
-      "standard": "标准（推荐，歌名一致且艺术家匹配或包含）",
+      "strict": "严格（平台 ID 匹配，或歌名与艺术家完全一致且专辑一致）",
+      "standard": "标准（推荐，歌名与艺术家匹配，优先匹配专辑）",
       "loose": "宽松（仅歌名一致即可，同名不同曲可能误匹）"
     },
     "fileCacheManager": {

--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -345,6 +345,7 @@ export const watchLyricPreference = (): void => {
       settings.system.lyric.enableOnlineTTMLLyric,
       settings.system.localLyric.enableLocalTTMLOverride,
       settings.system.localLyric.repoDir,
+      settings.system.localLyric.matchLevel,
     ],
     () => {
       refreshPreference();

--- a/src/services/lyric/preload.ts
+++ b/src/services/lyric/preload.ts
@@ -41,6 +41,7 @@ const buildContextKey = (): string => {
     settings.system.lyric.enableOnlineTTMLLyric,
     settings.system.localLyric.enableLocalTTMLOverride,
     settings.system.localLyric.repoDir,
+    settings.system.localLyric.matchLevel,
     streaming.activeServerId ?? "",
     plugins.list.map((plugin) => [
       plugin.manifest.id,

--- a/src/services/nextTrackPreloader.ts
+++ b/src/services/nextTrackPreloader.ts
@@ -230,6 +230,7 @@ export const installNextTrackPreloadWatchers = (): void => {
       settings.system.lyric.enableOnlineTTMLLyric,
       settings.system.localLyric.enableLocalTTMLOverride,
       settings.system.localLyric.repoDir,
+      settings.system.localLyric.matchLevel,
       plugins.list
         .map((plugin) =>
           JSON.stringify([

--- a/src/settings/categories/lyric.ts
+++ b/src/settings/categories/lyric.ts
@@ -120,6 +120,17 @@ const lyricCategory: SettingCategory = {
               component: LocalLyricRepoConfig,
               binding: { store: "settings", path: "system.localLyric.repoDir" },
             },
+            {
+              key: "localLyricMatchLevel",
+              type: "select",
+              binding: { store: "settings", path: "system.localLyric.matchLevel" },
+              options: [
+                { value: "strict", labelKey: "settings.localLyricMatchLevel.strict" },
+                { value: "standard", labelKey: "settings.localLyricMatchLevel.standard" },
+                { value: "loose", labelKey: "settings.localLyricMatchLevel.loose" },
+              ],
+              defaultValue: "standard",
+            },
           ],
         },
       ],


### PR DESCRIPTION
## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

### 背景与动机
此前本地 TTML 歌词库（`localLyricRepo`）在按标题匹配时，仅根据歌名进行匹配，同名文件只有 1 首时直接命中，多首且艺术家不符时依然兜底返回第 1 首。这不仅会导致不同歌手的“同名异曲”被错误覆盖，也会导致同一歌手同一歌曲的“不同专辑版本”（如录音室版 vs. 演唱会 Live 版）因缺乏专辑元数据匹配而选错版本、时间戳错乱。

### 主要改动
1. **补全 AMLL 专辑元数据提取**：
   - 在 `localLyricRepo` 中解析 `<amll:meta key="album" ...>` 标签（并兼容 `albumName`），支持多专辑标签拼接合并。
2. **新增三档匹配强度（`LocalLyricMatchLevel`）**：
   - **严格 (`strict`)**：必须通过平台数字 ID 精确命中，或歌名与艺术家完全一致；双方均有专辑时专辑也必须匹配（严格杜绝录音室与现场版错配）；不接受模糊包含，元数据缺失时不匹配。
   - **标准 (`standard`，默认推荐)**：歌名必须一致，艺术家必须匹配（支持合唱、`feat.` 包含）；多版本时根据专辑匹配度自动择优消歧（专辑一致优先）；双方均有明确艺术家但互不相干时**坚决拒绝兜底**，避免同名异曲误匹配。
   - **宽松 (`loose`)**：保持原有宽松容错行为，多候选时按艺术家与专辑评分挑选最佳候选，无匹配兜底首个。
3. **设置项交互与 UI 布局**：
   - 在设置中心“歌词设置” $\to$ **“TTML 歌词”** 分组中，将“匹配强度”下拉选择框置于“启用本地 TTML 歌词库”的从属配置中（紧随“歌词库目录”之后），并与开关状态联动。
   - 支持实时热生效：修改匹配强度后即时重新计算当前歌曲歌词，并使下一首预加载缓存失效重算。
4. **国际化与工具复用**：
   - 复用 `utils.ts` 中的 `artistMatches`、`normalizeTrackArtists` 和 `bothContains`；
   - 补全 `zh-CN` 与 `en-US` 翻译。

## 关联 Issue

<!-- 如有关联，填 #编号；无则可留空 -->

## 测试情况

- [x] **类型检查**：运行 `pnpm typecheck`（Node 与 Web 端类型编译）均通过。
- [x] **自动化测试**：运行 `pnpm test:web`，10 个测试文件（57 个用例）全部通过。
- [x] **多场景验证**：
  - 同名同歌手不同专辑场景（如录音室版 vs. 演唱会版）：标准模式能精准根据专辑名挑中最优匹配版本；严格模式下专辑冲突时拒绝错配。
  - 同名异曲场景（歌手完全不同）：标准模式和严格模式均能正确拒绝匹配，正常 fallback 到在线歌词。
  - 合唱 / `feat.` 场景：标准模式支持包含匹配正常命中。
- [x] **代码格式化**：已运行 Prettier 格式化所有修改文件，符合项目编码规范。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交