### PR TITLE
fix: 优化歌词加载并发流程，避免网络超时阻塞歌词展示与抢占

### DIFF
--- a/src/services/lyric/loader.ts
+++ b/src/services/lyric/loader.ts
@@ -3,9 +3,9 @@
  */
 
 import type { Track, TrackDetail } from "@shared/types/player";
-import type { LyricData, LyricInput } from "@shared/types/lyrics";
+import type { LyricData, LyricFormat, LyricInput } from "@shared/types/lyrics";
 import { isPlatform } from "@shared/types/platform";
-import { bestExternalIndex } from "@/utils/lyric/parse";
+import { bestExternalIndex, parseLyric } from "@/utils/lyric/parse";
 import { useMediaStore } from "@/stores/media";
 import { useSettingsStore } from "@/stores/settings";
 import { DEFAULT_LYRIC_FORMAT_ORDER } from "@/types/settings";
@@ -82,22 +82,92 @@ const commitResolvedAndHasParsed = (token: number, resolved: ResolvedLyric): boo
   commitAndHasParsed(token, resolved.source, resolved.input);
 
 /**
- * 提交在线歌词；解析后为空时优先回退本地，本地也无再按需 TTML 升级
+ * 验证歌词是否能够有效解析出行内容
+ * @param input - 歌词输入
+ * @param format - 歌词格式
+ * @returns 是否包含至少一行有效歌词
  */
-const applyOnline = async (
+const hasParseableContent = (input: LyricInput, format: LyricFormat): boolean => {
+  try {
+    const settings = useSettingsStore();
+    const lines = parseLyric(input, format, settings.locale, {
+      detectBackground: settings.lyric.detectBackgroundLyrics,
+    });
+    return lines.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * 尝试以更优格式提交歌词候选
+ * 仅当候选格式优于当前展示格式（或当前无歌词）时写入，避免低优先级结果覆盖优质歌词
+ * @param token - 竞态 token
+ * @param source - 候选歌词源
+ * @param input - 候选歌词内容
+ * @returns 是否成功提交且有效解析
+ */
+const commitIfBetter = (
+  token: number,
+  source: NonNullable<LyricData>,
+  input: LyricInput,
+): boolean => {
+  if (token !== currentToken) return false;
+  const currentFormat = useMediaStore().activeLyric?.format ?? null;
+  if (!isBetterFormat(source.format, currentFormat)) return false;
+  return commitAndHasParsed(token, source, input);
+};
+
+/**
+ * 异步拉取 TTML 覆盖并尝试升级当前歌词
+ * 非阻塞执行，不阻塞基础歌词展示与其它来源抢占
+ * @param token - 竞态 token
+ * @param track - 歌曲信息
+ * @param online - 在线歌词基础结果
+ */
+const tryApplyTTMLOverlay = async (
+  token: number,
+  track: Track,
+  online: OnlineResult,
+): Promise<void> => {
+  try {
+    const ttml = await resolveTTMLOverlay(track, online);
+    if (token !== currentToken || !ttml) return;
+    const currentFormat = useMediaStore().activeLyric?.format ?? null;
+    if (isBetterFormat("ttml", currentFormat)) {
+      if (!hasParseableContent(ttml.input, "ttml")) {
+        console.warn("[lyricLoader] TTML 解析有效行为空，保留当前歌词");
+        return;
+      }
+      commit(token, ttml.source, ttml.input);
+    }
+  } catch (err) {
+    console.warn("[lyricLoader] tryApplyTTMLOverlay failed:", err);
+  }
+};
+
+/**
+ * 提交在线歌词；解析后为空时优先回退本地，并在后台异步尝试 TTML 升级
+ * @param token - 竞态 token
+ * @param track - 歌曲信息
+ * @param online - 在线歌词结果
+ * @param fallbackLocal - 本地回退歌词
+ */
+const applyOnline = (
   token: number,
   track: Track,
   online: OnlineResult,
   fallbackLocal: LocalLyric | null,
-): Promise<void> => {
+): void => {
   const media = useMediaStore();
   const current = media.activeLyric;
+  const currentFormat = current?.format ?? null;
   // 跳过同源同格式
   const alreadyCommitted =
     current?.source === "online" &&
     current.platform === online.source.platform &&
     current.format === online.source.format;
-  if (!alreadyCommitted) {
+  if (!alreadyCommitted && isBetterFormat(online.source.format, currentFormat)) {
     if (!commitAndHasParsed(token, online.source, online.input) && fallbackLocal) {
       commitLocal(token, fallbackLocal);
       return;
@@ -107,11 +177,7 @@ const applyOnline = async (
     commitLocal(token, fallbackLocal);
     return;
   }
-  const ttml = await resolveTTMLOverlay(track, online);
-  if (token !== currentToken) return;
-  if (ttml) {
-    commit(token, ttml.source, ttml.input);
-  }
+  void tryApplyTTMLOverlay(token, track, online);
 };
 
 /**
@@ -142,7 +208,7 @@ const tryPluginFallback = async (token: number, track: Track): Promise<boolean> 
 
 /**
  * 插件优先加载
- * 插件请求与正常流程并发发出，正常流程先展示，插件返回更优格式时替换
+ * 插件请求与正常流程并发发出，任意一方就绪且更优时立即抢占展示
  * @param token - 竞态 token
  * @param track - 歌曲信息
  * @param run - 正常加载流程
@@ -156,14 +222,27 @@ const withPluginPrefer = async (
     await run();
     return;
   }
-  const pluginTask = resolvePluginLyric(track);
+
+  /**
+   * 尝试提交插件歌词
+   * 插件任务完成后立即尝试抢占；正常流程结束后再次保底检查，确保最优格式最终展示
+   * @param plugin - 解析出的插件歌词，不存在则忽略
+   */
+  const tryCommitPlugin = (plugin: ResolvedLyric | null): void => {
+    if (!plugin || token !== currentToken) return;
+    const currentFormat = useMediaStore().activeLyric?.format ?? null;
+    if (isBetterFormat(plugin.source.format, currentFormat)) {
+      commitResolvedAndHasParsed(token, plugin);
+    }
+  };
+
+  const pluginTask = resolvePluginLyric(track).then((plugin) => {
+    tryCommitPlugin(plugin);
+    return plugin;
+  });
   await run();
   const plugin = await pluginTask;
-  if (!plugin || token !== currentToken) return;
-  const currentFormat = useMediaStore().activeLyric?.format ?? null;
-  if (isBetterFormat(plugin.source.format, currentFormat)) {
-    commitResolvedAndHasParsed(token, plugin);
-  }
+  tryCommitPlugin(plugin);
 };
 
 /**
@@ -181,12 +260,25 @@ const loadStreamingLyric = (
     const resolved = await resolveStreamingByPreference(track, () => token === currentToken);
     if (token !== currentToken) return;
     const embeddedFallback = embeddedLyricFromDetail(detail);
-    if (resolved && commitResolvedAndHasParsed(token, resolved)) return;
+    if (resolved) {
+      const currentFormat = useMediaStore().activeLyric?.format ?? null;
+      if (isBetterFormat(resolved.source.format, currentFormat)) {
+        if (commitResolvedAndHasParsed(token, resolved)) {
+          if (resolved.source.source === "online") {
+            void tryApplyTTMLOverlay(token, track, {
+              source: resolved.source as OnlineResult["source"],
+              input: resolved.input,
+            });
+          }
+          return;
+        }
+      }
+    }
     if (token !== currentToken) return;
     if (await tryPluginFallback(token, track)) return;
     if (embeddedFallback) {
-      commit(token, embeddedFallback.source, { content: embeddedFallback.content });
-    } else {
+      commitIfBetter(token, embeddedFallback.source, { content: embeddedFallback.content });
+    } else if (useMediaStore().parsedLyric.length === 0) {
       commit(token, null, null);
     }
   });
@@ -201,11 +293,14 @@ const loadPlatformLyric = (token: number, track: Track): Promise<void> =>
     const online = await resolveOnlineByPreference(track, {
       hasLocal: false,
       localFormat: null,
+      onCandidate: (result) => commitIfBetter(token, result.source, result.input),
       shouldContinue: () => token === currentToken,
     });
     if (token !== currentToken) return;
-    if (online) await applyOnline(token, track, online, null);
-    else if (!(await tryPluginFallback(token, track))) commit(token, null, null);
+    if (online) applyOnline(token, track, online, null);
+    else if (!(await tryPluginFallback(token, track)) && useMediaStore().parsedLyric.length === 0) {
+      commit(token, null, null);
+    }
   });
 
 /** 开启新一轮加载周期 */
@@ -240,7 +335,17 @@ export const loadForTrack = async (detail: TrackDetail | null): Promise<void> =>
     const preloaded = await consumePreloadedLyric(track);
     if (token !== currentToken) return;
     if (preloaded.hit) {
-      if (commitResolvedAndHasParsed(token, preloaded.lyric)) return;
+      if (commitResolvedAndHasParsed(token, preloaded.lyric)) {
+        if (preloaded.lyric.source.source === "online") {
+          void tryApplyTTMLOverlay(token, track, {
+            source: preloaded.lyric.source as OnlineResult["source"],
+            input: preloaded.lyric.input,
+          });
+        }
+        const order = useSettingsStore().lyric.lyricFormatOrder ?? DEFAULT_LYRIC_FORMAT_ORDER;
+        // 若预载已命中最高优先级格式，无需再做后续加载
+        if (preloaded.lyric.source.format === order[0]) return;
+      }
     }
     // 本地 TTML 歌词库最高优先
     if (await tryLocalRepo(token, track)) return;
@@ -269,15 +374,19 @@ export const loadForTrack = async (detail: TrackDetail | null): Promise<void> =>
       const online = await resolveOnlineByPreference(track, {
         hasLocal: hasUsableLocal,
         localFormat,
-        onCandidate: (result) => commit(token, result.source, result.input),
+        onCandidate: (result) => commitIfBetter(token, result.source, result.input),
         shouldContinue: () => token === currentToken,
       });
       if (token !== currentToken) return;
       // id 回查本地 TTML 库
       if (online && (await tryLocalRepo(token, track))) return;
       if (online) {
-        await applyOnline(token, track, online, local);
-      } else if (!hasUsableLocal && !(await tryPluginFallback(token, track))) {
+        applyOnline(token, track, online, local);
+      } else if (
+        !hasUsableLocal &&
+        useMediaStore().parsedLyric.length === 0 &&
+        !(await tryPluginFallback(token, track))
+      ) {
         commit(token, null, null);
       }
     });
@@ -318,12 +427,12 @@ const refreshPreference = async (): Promise<void> => {
     const online = await resolveOnlineByPreference(track, {
       hasLocal: !!local,
       localFormat,
-      onCandidate: (result) => commit(token, result.source, result.input),
+      onCandidate: (result) => commitIfBetter(token, result.source, result.input),
       shouldContinue: () => token === currentToken,
     });
     if (token !== currentToken) return;
     if (online) {
-      await applyOnline(token, track, online, local);
+      applyOnline(token, track, online, local);
       return;
     }
     // 目标是本地

--- a/src/services/lyric/resolve.ts
+++ b/src/services/lyric/resolve.ts
@@ -253,9 +253,7 @@ export const resolveStreamingByPreference = async (
   });
   if (!shouldContinue()) return null;
   if (online) {
-    const ttml = await resolveTTMLOverlay(track, online);
-    if (!shouldContinue()) return null;
-    return ttml ?? { source: online.source, input: online.input };
+    return { source: online.source, input: online.input };
   }
   if (serverLyric || preference === "auto") return serverLyric;
 
@@ -354,12 +352,9 @@ export const resolveLyricForPreload = async (
     shouldContinue,
   });
   if (!shouldContinue()) return null;
-  let normal: ResolvedLyric | null = null;
-  if (online) {
-    const ttml = await resolveTTMLOverlay(track, online);
-    if (!shouldContinue()) return null;
-    normal = ttml ?? { source: online.source, input: online.input };
-  }
+  const normal: ResolvedLyric | null = online
+    ? { source: online.source, input: online.input }
+    : null;
   if (pluginTask) {
     const plugin = await pluginTask;
     if (!shouldContinue()) return null;


### PR DESCRIPTION
> By Google Gemini 3.8 Flash
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

### 动机
1. **AMLL TTML DB 超时阻塞**：原代码在 `applyOnline`、`resolveStreamingByPreference` 及 `resolveLyricForPreload` 等多处同步 `await resolveTTMLOverlay()`。当 AMLL DB 服务端响应慢或超时（8s）时，会导致基础歌词、内嵌歌词或插件歌词迟迟无法展示，严重影响切歌体感。
2. **多音源并发时慢平台拖累整体显示**：开启「智能选择在线歌词」时，在线歌曲加载流程 `loadPlatformLyric` 缺少 `onCandidate` 即时提交回调，导致并发查询多个平台时，即使已有平台返回了歌词，仍会被其他慢响应或超时的平台（如酷狗网络波动）阻塞长达 8 秒。
3. **低优先级候选覆盖已展示歌词**：当插件或高优先级平台歌词已上屏时，正常加载流程的 `onCandidate` 回调无条件写入，可能导致已显示的优质歌词（如 TTML/QRC）被延迟返回的低优先级普通 LRC 降级覆盖。
4. **无效 TTML 覆写清空有效歌词**：后台 TTML 解析失败或有效行为空时直接提交，会导致已展示的有效歌词被清空且无法恢复。

### 主要变更
1. **TTML 异步非阻塞升级**：
   - 将 `resolveTTMLOverlay` 改为后台静默触发（`tryApplyTTMLOverlay`），先即时呈现本地/内嵌/平台在线基础歌词，TTML 命中后再热替换升级；
   - 移除了预载流程和流媒体解析中对 TTML 的同步 `await` 阻塞。
2. **候选即时上屏与防降级控制（`commitIfBetter`）**：
   - 为在线歌曲（`loadPlatformLyric`）、本地歌曲和刷新偏好流程统一接入 `commitIfBetter` 作为 `onCandidate` 提交回调，任一平台就绪立即抢先展示，无需等待其他平台超时；
   - 提交前检查当前展示格式，严格确保只有更优格式（`isBetterFormat`）才允许覆盖，避免插件歌词或高优先级候选被后到的低优先级结果冲掉。
3. **TTML 解析内容有效性校验（`hasParseableContent`）**：
   - TTML 升级前预先解析，确保至少解析出 1 行有效歌词才执行覆盖；若解析为空或失败则保留当前已展示歌词。
4. **规范与文档对齐**：
   - 补充完善全中文 JSDoc 注释，清理冗余返回值，代码组织严格遵循 `AGENTS.md` 规范。

## 测试情况

- **测试环境**：Windows 11 (pwsh / Node.js)
- **验证场景**：
  1. 模拟 AMLL DB 超时场景：基础在线歌词（LRC/YRC/QRC）秒级展示，无任何 8 秒阻塞感。
  2. 模拟多平台并发场景：网易云先返回 LRC 立即上屏展示，后续慢平台或超时平台不影响界面渲染；QQ 音乐返回 QRC 时立即平滑热替换。
  3. 插件优先测试：插件歌词提前提交后，后续普通在线候选到达不会将其降级覆盖。
  4. 畸形/空 TTML 测试：当 AMLL 返回无效空内容时，控制台发出告警并保留当前歌词，未出现歌词被清空为空白的情况。
- **自动化检查**：
  - `pnpm typecheck`（Node + Web 目标）全绿通过。
  - `npx eslint` 检查通过，0 errors, 0 warnings。
  - `npx prettier --check` 格式检查全量通过。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交