### PR TITLE
feat: 增强 CJK 歌词语言处理逻辑

### DIFF
--- a/src/utils/lyric/language.ts
+++ b/src/utils/lyric/language.ts
@@ -1,4 +1,4 @@
-import type { LyricLine } from "@shared/types/lyrics";
+import type { LyricLanguage, LyricLine } from "@shared/types/lyrics";
 
 /** 日语假名：平假名 + 片假名 + 半角假名 + 促音/长音符号 */
 const KANA_RE = /[\p{Script=Hiragana}\p{Script=Katakana}\u30FC\uFF66-\uFF9F]/u;
@@ -18,57 +18,97 @@ const hasTranslation = (line: LyricLine): boolean => line.translatedLyric.trim()
 /**
  * 为歌词行补充语言信息
  *
- * Han 脚本无法独立区分中日韩；
- * - 同一首歌词出现假名时，通常将纯汉字行视为日语；
- * - 同一首歌词出现谚文时，通常将纯汉字行视为韩语；
- * - CJK 混合启发式规则：若所有包含假名/谚文的行均有翻译，
- *   则认定全为汉字且无翻译的行为中文，以此区分双语混合歌词。
+ * - Han 脚本无法独立区分中日韩，对此会根据翻译和比例推断语言，详见代码实现
  * - 拉丁文字使用 BCP 47 的 und-Latn，避免误标为英语。
  *
  * @param lines - 已解析的整首歌词
  */
 export const applyLyricLanguages = (lines: LyricLine[]): void => {
-  const lineContents = lines.map((line) => line.words.map((word) => word.word).join(""));
+  const lineContents = lines.map((line) =>
+    line.words
+      .map((word) => {
+        // 这里将 ruby 内容也算作歌词内容的一部分，以考虑纯汉字行但 ruby 为假名的情况
+        const rubyText = word.ruby?.map((span) => span.word).join("");
+        return `${word.word}${rubyText ? `(${rubyText})` : ""}`;
+      })
+      .join(""),
+  );
 
-  let hasKana = false;
-  let hasHangul = false;
-  let kanaUntranslatedCount = 0;
-  let hangulUntranslatedCount = 0;
+  // 统计全局行级 CJK 特征
+  let hanLineCount = 0;
+  let kanaLineCount = 0;
+  let hangulLineCount = 0;
+  let kanaTranslatedCount = 0;
+  let hangulTranslatedCount = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const content = lineContents[i];
     const isTranslated = hasTranslation(lines[i]);
 
+    if (HAN_RE.test(content)) {
+      hanLineCount++;
+    }
     if (KANA_RE.test(content)) {
-      hasKana = true;
-      if (!isTranslated) kanaUntranslatedCount++;
+      kanaLineCount++;
+      if (isTranslated) kanaTranslatedCount++;
     }
     if (HANGUL_RE.test(content)) {
-      hasHangul = true;
-      if (!isTranslated) hangulUntranslatedCount++;
+      hangulLineCount++;
+      if (isTranslated) hangulTranslatedCount++;
     }
   }
 
-  const allKanaTranslated = hasKana && kanaUntranslatedCount === 0;
-  const allHangulTranslated = hasHangul && hangulUntranslatedCount === 0;
+  const hasHan = hanLineCount > 0;
+  const hasKana = kanaLineCount > 0;
+  const hasHangul = hangulLineCount > 0;
 
+  // CJK 翻译启发式标志
+  const allKanaTranslated = hasKana && kanaTranslatedCount === kanaLineCount;
+  const allHangulTranslated = hasHangul && hangulTranslatedCount === hangulLineCount;
+
+  // CJK 比例
+  const kanaRatio = hasHan ? kanaLineCount / hanLineCount : Infinity;
+  const hangulRatio = hasHan ? hangulLineCount / hanLineCount : Infinity;
+  const THRESHOLD = 0.37; // 我猜的
+
+  let mainCJK: LyricLanguage = "zh-CN";
+  if (hasHan) {
+    if (kanaRatio > THRESHOLD && hangulRatio > THRESHOLD) {
+      mainCJK = hangulLineCount > kanaLineCount ? "ko" : "ja";
+    } else if (kanaRatio > THRESHOLD) {
+      mainCJK = "ja";
+    } else if (hangulRatio > THRESHOLD) {
+      mainCJK = "ko";
+    } else {
+      mainCJK = "zh-CN";
+    }
+  }
+
+  // 判断纯汉字行的语言
+  const getPureHanLineLang = (line: LyricLine): LyricLanguage => {
+    const isTranslated = hasTranslation(line);
+
+    if (allKanaTranslated) {
+      return isTranslated ? "ja" : "zh-CN";
+    }
+    if (allHangulTranslated) {
+      return isTranslated ? "ko" : "zh-CN";
+    }
+
+    return mainCJK;
+  };
+
+  // 逐行标注
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const content = lineContents[i];
-    const isTranslated = hasTranslation(line);
 
     if (KANA_RE.test(content)) {
       line.language = "ja";
     } else if (HANGUL_RE.test(content)) {
       line.language = "ko";
     } else if (HAN_RE.test(content)) {
-      if (hasKana) {
-        line.language = allKanaTranslated && !isTranslated ? "zh-CN" : "ja";
-      } else if (hasHangul) {
-        line.language = allHangulTranslated && !isTranslated ? "zh-CN" : "ko";
-      } else {
-        line.language = "zh-CN";
-      }
+      line.language = getPureHanLineLang(line);
     } else if (LATIN_RE.test(content)) {
       line.language = "und-Latn";
     } else {


### PR DESCRIPTION
## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

原先的根据翻译的启发式判断还是会误判某些情况，比如由 [kid141252010](https://github.com/kid141252010) 反馈的 [《等你的回答》](https://music.163.com/#/song?id=2602727516)，这首歌仅有开头的制作人有谚文，但却被整首歌判为韩语

此 PR 增加了判断包含假名或谚文的行与包含汉字的行的比值是否超过阈值判断 CJK 的主语言，避免了这种情况下的误判。除此之外，也将 ruby 内容也算作歌词内容的一部分，以考虑纯汉字行但 ruby 为假名的情况

比例的阈值 `THRESHOLD = 0.37` 是我根据 [《人是猫》](https://music.163.com/#/song?id=3395708493) 的 `12 / 33 ≈ 0.3636363636` 猜的，是否适用于所有情况还未知

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [ ] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [ ] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交

> `pnpm format` 无法通过。但这与此 PR 无关
