### PR TITLE
feat: 强迫症设置：拒绝胎教模式（剔除 TTML 汉语拼音音译）

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -830,6 +830,10 @@
       "label": "Show Subtitle",
       "description": "Show alias and other subtitle info in song list"
     },
+    "noPinyin": {
+      "label": "Filter Pinyin Mode",
+      "description": "Filter out Mandarin Pinyin transliterations in TTML lyrics"
+    },
     "rememberLastTrack": {
       "label": "Remember Progress",
       "description": "Restore playback position on startup"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -818,6 +818,10 @@
       "label": "显示副标题",
       "description": "歌曲列表中显示别名等副标题信息"
     },
+    "noPinyin": {
+      "label": "拒绝胎教模式",
+      "description": "遇到普通话汉语拼音音译时自动剔除，保留其他语言音译"
+    },
     "rememberLastTrack": {
       "label": "记忆播放进度",
       "description": "启动时恢复上次歌曲的播放进度"

--- a/src/settings/categories/other.ts
+++ b/src/settings/categories/other.ts
@@ -1,4 +1,5 @@
 import type { SettingCategory } from "@/types/settings-schema";
+import { useSettingsStore } from "@/stores/settings";
 import PlatformAccount from "@/components/settings/custom/PlatformAccount.vue";
 import IconLucideSettings from "~icons/lucide/settings";
 
@@ -91,6 +92,13 @@ const otherCategory: SettingCategory = {
           type: "switch",
           binding: { store: "settings", path: "preset.showSubtitle" },
           defaultValue: true,
+        },
+        {
+          key: "noPinyin",
+          type: "switch",
+          binding: { store: "settings", path: "preset.noPinyin" },
+          defaultValue: false,
+          visible: () => useSettingsStore().locale.startsWith("zh"),
         },
       ],
     },

--- a/src/stores/media.ts
+++ b/src/stores/media.ts
@@ -137,7 +137,11 @@ export const useMediaStore = defineStore("media", () => {
 
   // 监听简繁转换及强迫症设置变化并重新解析当前歌词
   watch(
-    () => [useSettingsStore().lyric.cjkTransform, useSettingsStore().preset.uncensorProfanity],
+    () => [
+      useSettingsStore().lyric.cjkTransform,
+      useSettingsStore().preset.uncensorProfanity,
+      useSettingsStore().preset.noPinyin,
+    ],
     () => {
       if (activeLyric.value && lyricContent.value) {
         setLyric(activeLyric.value, lyricContent.value);
@@ -157,6 +161,7 @@ export const useMediaStore = defineStore("media", () => {
       try {
         const lines = parseLyric(input, source.format, settings.locale, {
           detectBackground: settings.lyric.detectBackgroundLyrics,
+          filterPinyin: settings.preset.noPinyin,
         });
         nextLines = applyLyricExclude(lines, track.value);
         normalizeLyricLines(nextLines);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -160,6 +160,7 @@ export const useSettingsStore = defineStore(
       hideVipTag: false,
       hideQualityTag: false,
       showSubtitle: true,
+      noPinyin: false,
     });
 
     /** 歌词 */
@@ -359,12 +360,16 @@ export const useSettingsStore = defineStore(
       storage: localStorage,
       omit: ["system"],
       afterHydrate: ({ store }) => {
-        const { lyric, appearance } = store as unknown as {
+        const { lyric, appearance, preset } = store as unknown as {
           lyric: LyricSettings;
           appearance: AppearanceSettings;
+          preset: PresetSettings;
         };
         if (typeof lyric.detectBackgroundLyrics !== "boolean") {
           lyric.detectBackgroundLyrics = true;
+        }
+        if (typeof preset?.noPinyin !== "boolean") {
+          preset.noPinyin = false;
         }
         lyric.lyricSourceOrder = reconcileOrder(lyric.lyricSourceOrder, ALL_PLATFORMS);
         lyric.lyricFormatOrder = reconcileOrder(lyric.lyricFormatOrder, DEFAULT_LYRIC_FORMAT_ORDER);

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -298,4 +298,6 @@ export interface PresetSettings {
   hideQualityTag: boolean;
   /** 显示歌曲副标题（别名） */
   showSubtitle: boolean;
+  /** 拒绝胎教模式（剔除 TTML 汉语拼音音译） */
+  noPinyin: boolean;
 }

--- a/src/utils/lyric/parse.ts
+++ b/src/utils/lyric/parse.ts
@@ -12,6 +12,8 @@ import { normalizeKangxi } from "./kangxi";
 
 export interface ParseLyricOptions {
   detectBackground?: boolean;
+  /** 是否剔除普通话汉语拼音音译（TTML） */
+  filterPinyin?: boolean;
 }
 
 /**
@@ -82,7 +84,7 @@ const parseContent = (
   const detectBackground = options.detectBackground !== false;
   switch (format) {
     case "ttml":
-      return parseTTML(text, preferredLang);
+      return parseTTML(text, preferredLang, { filterPinyin: options.filterPinyin });
     case "qrc":
       return parseQRC(text, detectBackground);
     case "krc":

--- a/src/utils/lyric/parseTTML.ts
+++ b/src/utils/lyric/parseTTML.ts
@@ -88,6 +88,36 @@ const normalizeLang = (lang: string | null | undefined): string =>
   (lang ?? "").toLowerCase().replace(/_/g, "-");
 
 /**
+ * 判断语言标签是否为普通话汉语拼音（排除粤拼等方言方案及其他语言）
+ * @param rawLang - 原始语言标签
+ * @returns 是否为汉语拼音
+ */
+export const isPinyinTransliteration = (rawLang: string | null | undefined): boolean => {
+  if (!rawLang) return false;
+  const lang = rawLang.trim().toLowerCase().replace(/_/g, "-");
+  if (!lang) return false;
+
+  // 排除粤语拼音（如 zh-Latn-jyutping, zh-Latn-jyupin, yue-Latn 等）及其他方言方案
+  if (
+    lang.includes("jyutping") ||
+    lang.includes("jyupin") ||
+    lang.includes("cantonese") ||
+    lang.startsWith("yue")
+  ) {
+    return false;
+  }
+
+  // 匹配普通话汉语拼音：zh-Latn-pinyin, zh-pinyin, cmn-Latn-pinyin, zh-cmn-Latn-pinyin 等
+  return (
+    lang === "zh-latn-pinyin" ||
+    lang === "zh-pinyin" ||
+    lang === "cmn-latn-pinyin" ||
+    lang === "zh-cmn-latn-pinyin" ||
+    ((lang.startsWith("zh") || lang.startsWith("cmn")) && lang.includes("pinyin"))
+  );
+};
+
+/**
  * 从多语言候选中选出最匹配偏好语言的索引
  * @param langs 候选语言标签数组，顺序与候选一致
  * @param preferred 偏好语言标签（如 zh-CN），为空则取首个
@@ -191,13 +221,27 @@ interface TransliterationMaps {
 }
 
 /**
+ * 查找元素归属的 transliteration 容器节点
+ * @param el 目标元素
+ */
+const findTransliterationEl = (el: Element): Element | null => {
+  let curr: Element | null = el.parentElement;
+  while (curr && curr.nodeType === Node.ELEMENT_NODE) {
+    if (curr.localName === "transliteration") return curr;
+    curr = curr.parentElement;
+  }
+  return null;
+};
+
+/**
  * 收集 iTunes 音译元数据（transliterations 段中的 text[for] 元素）
  *
  * 纯文本节点累积为行级音译；带 begin/end 的子 span 视为逐词罗马音，
  * 嵌套在 x-bg 元素内的归背景行
  * @param doc XML 文档
+ * @param filterPinyin 是否剔除普通话拼音音译
  */
-const collectTransliterations = (doc: Document): TransliterationMaps => {
+const collectTransliterations = (doc: Document, filterPinyin = false): TransliterationMaps => {
   const lines = new Map<string, { main: string; bg: string }>();
   const words = new Map<string, { main: RomanWord[]; bg: RomanWord[] }>();
 
@@ -207,6 +251,12 @@ const collectTransliterations = (doc: Document): TransliterationMaps => {
       !parent ||
       (parent.localName !== "transliteration" && !parent.closest("transliterations"))
     ) {
+      continue;
+    }
+
+    const transEl = findTransliterationEl(textEl) ?? parent;
+    const lang = getAttr(transEl, "lang");
+    if (filterPinyin && isPinyinTransliteration(lang)) {
       continue;
     }
 
@@ -303,22 +353,34 @@ const alignRomanWords = (words: LyricWord[], romanWords: RomanWord[]): void => {
   }
 };
 
+/** TTML 解析选项 */
+export interface ParseTTMLOptions {
+  /** 是否剔除普通话汉语拼音音译 */
+  filterPinyin?: boolean;
+}
+
 /**
  * 解析 TTML 歌词文本
  * @param text TTML XML 文本内容
  * @param preferredLang 偏好翻译语言标签
+ * @param options 解析选项
  * @returns 解析后的歌词行数组
  * @throws 当 XML 解析失败时抛出错误
  */
-export const parseTTML = (text: string, preferredLang = ""): LyricLine[] => {
+export const parseTTML = (
+  text: string,
+  preferredLang = "",
+  options: ParseTTMLOptions = {},
+): LyricLine[] => {
   const doc = new DOMParser().parseFromString(text, "application/xml");
   if (doc.querySelector("parsererror")) {
     throw new Error("Invalid TTML XML");
   }
 
+  const filterPinyin = options.filterPinyin === true;
   const { mainAgent, agentTypes } = collectAgents(doc);
   const translations = collectTranslations(doc, preferredLang);
-  const transliterations = collectTransliterations(doc);
+  const transliterations = collectTransliterations(doc, filterPinyin);
   const lines: LyricLine[] = [];
 
   /**
@@ -406,7 +468,12 @@ export const parseTTML = (text: string, preferredLang = ""): LyricLine[] => {
           });
         } else if (role === "x-roman") {
           // 行内音译
-          if (!line.romanLyric) line.romanLyric = span.textContent?.trim() ?? "";
+          if (!line.romanLyric) {
+            const spanLang = getAttr(span, "lang");
+            if (!filterPinyin || !isPinyinTransliteration(spanLang)) {
+              line.romanLyric = span.textContent?.trim() ?? "";
+            }
+          }
         } else {
           // 逐字 span
           const wb = getAttr(span, "begin");


### PR DESCRIPTION
## 改动类型

- [x] 新功能（feat）
- [ ] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

部分中文歌曲的 TTML 歌词中自带普通话汉语拼音音译（如 `<transliteration xml:lang="zh-Latn-pinyin">`），对于中文母语者较为冗余且影响排版。

本 PR 在“其它设置 → 强迫症设置”中新增**拒绝胎教模式**：
1. **设置项**：默认关闭，仅在应用语言为中文时可见；切换后即时重新解析当前播放歌词。
2. **音译过滤**：
   - 自动剔除 TTML 歌词中的普通话汉语拼音音译（行级与逐字音译均剔除）；
   - 粤语拼音（粤拼）、其他外语罗马音及无语言声明的音译均保持原样正常传下，不作处理。

## 测试情况

- 播放包含普通话拼音的 TTML 歌曲，切换“拒绝胎教模式”开关，歌词面板即时剔除 / 恢复拼音音译；
- 验证粤拼与其他语言音译不受影响、正常显示；
- 切换应用语言为英文，设置项按预期自动隐藏；
- 本地单元测试与类型检查全部通过。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交