### PR TITLE
fix: 优先使用音源插件

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -870,6 +870,10 @@
       "label": "Allow Trial Playback",
       "description": "Play trial clips returned by the platform only when full sources and plugins are unavailable"
     },
+    "preferPluginSource": {
+      "label": "Prefer Plugin Audio Source",
+      "description": "Prioritize getting playback URLs from enabled source plugins, falling back to official online sources if failed"
+    },
     "preloadNextTrack": {
       "label": "Preload next track",
       "description": "Fetch the next track's playback info in advance, which may increase network usage"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -858,6 +858,10 @@
       "label": "允许播放试听",
       "description": "完整音源和插件都不可用时，允许播放平台返回的试听片段"
     },
+    "preferPluginSource": {
+      "label": "优先使用插件音源",
+      "description": "播放时优先从已启用的音源插件获取音频直链，失败时回退至官方接口"
+    },
     "preloadNextTrack": {
       "label": "预载下一首歌曲",
       "description": "提前获取下一首的播放信息，可能会增加网络占用"

--- a/src/services/audioSource.ts
+++ b/src/services/audioSource.ts
@@ -151,18 +151,25 @@ export const resolveByPlugin = async (
 };
 
 /**
- * 解析在线音频源 URL
- * @param track - 要解析的 track
- * @param songLevel - 在线歌曲音质档位（仅内置官方接口生效）
+ * 官方在线平台接口解析结果
  */
-const resolveOnlineUrl = async (
+interface OfficialResolveOutcome {
+  resolved: OnlineResolveResult | null;
+  trialUrl: string | null;
+  officialErrorCode: ErrorCode | null;
+}
+
+/**
+ * 解析官方内置在线接口
+ */
+const resolveOfficialOnlineUrl = async (
   track: Track,
   songLevel: QualityLevel,
-  options: ResolveTrackSourceOptions = {},
-): Promise<OnlineResolveResult> => {
-  const settings = useSettingsStore();
+  options: ResolveTrackSourceOptions,
+): Promise<OfficialResolveOutcome> => {
   let trialUrl: string | null = null;
   let officialErrorCode: ErrorCode | null = null;
+
   if (track.source === "netease" && !options.skipOfficialOnline) {
     const user = useUserStore();
     try {
@@ -173,7 +180,11 @@ const resolveOnlineUrl = async (
       if (!resolved.available) {
         officialErrorCode = resolved.errorCode;
       } else if (!resolved.isTrial) {
-        return { ok: true, url: resolved.url, isTrial: false, provider: "official" };
+        return {
+          resolved: { ok: true, url: resolved.url, isTrial: false, provider: "official" },
+          trialUrl: null,
+          officialErrorCode: null,
+        };
       } else {
         trialUrl = resolved.url;
       }
@@ -182,11 +193,16 @@ const resolveOnlineUrl = async (
       officialErrorCode = ErrorCode.URL_RESOLVE_FAILED;
     }
   }
+
   if (track.source === "qqmusic" && !options.skipOfficialOnline) {
     try {
       const resolved = await resolveQQMusicUrl(track, songLevel);
       if (resolved.available) {
-        return { ok: true, url: resolved.url, isTrial: false, provider: "official" };
+        return {
+          resolved: { ok: true, url: resolved.url, isTrial: false, provider: "official" },
+          trialUrl: null,
+          officialErrorCode: null,
+        };
       }
       officialErrorCode = resolved.errorCode;
     } catch (err) {
@@ -194,11 +210,16 @@ const resolveOnlineUrl = async (
       officialErrorCode = ErrorCode.URL_RESOLVE_FAILED;
     }
   }
+
   if (track.source === "kugou" && !options.skipOfficialOnline) {
     try {
       const resolved = await resolveKugouUrl(track, songLevel);
       if (resolved.available) {
-        return { ok: true, url: resolved.url, isTrial: false, provider: "official" };
+        return {
+          resolved: { ok: true, url: resolved.url, isTrial: false, provider: "official" },
+          trialUrl: null,
+          officialErrorCode: null,
+        };
       }
       officialErrorCode = resolved.errorCode;
     } catch (err) {
@@ -206,14 +227,57 @@ const resolveOnlineUrl = async (
       officialErrorCode = ErrorCode.URL_RESOLVE_FAILED;
     }
   }
-  const pluginResolved = await resolveByPlugin(track, songLevel, options.skipPluginIds ?? []);
-  if (pluginResolved.ok) return pluginResolved;
+
+  return { resolved: null, trialUrl, officialErrorCode };
+};
+
+/**
+ * 解析在线音频源 URL
+ * @param track - 要解析的 track
+ * @param songLevel - 在线歌曲音质档位
+ */
+const resolveOnlineUrl = async (
+  track: Track,
+  songLevel: QualityLevel,
+  options: ResolveTrackSourceOptions = {},
+): Promise<OnlineResolveResult> => {
+  const settings = useSettingsStore();
+  const preferPlugin = settings.player.preferPluginSource;
+
+  // 若开启插件音源优先，先尝试音源插件
+  if (preferPlugin) {
+    const pluginResolved = await resolveByPlugin(track, songLevel, options.skipPluginIds ?? []);
+    if (pluginResolved.ok && !pluginResolved.isTrial) {
+      return pluginResolved;
+    }
+  }
+
+  // 尝试官方内置在线接口
+  const {
+    resolved: officialResolved,
+    trialUrl,
+    officialErrorCode,
+  } = await resolveOfficialOnlineUrl(track, songLevel, options);
+  if (officialResolved) {
+    return officialResolved;
+  }
+
+  // 若未开启插件优先（插件作为兜底），在官方失败后尝试插件
+  let pluginResolved: OnlineResolveResult | null = null;
+  if (!preferPlugin) {
+    pluginResolved = await resolveByPlugin(track, songLevel, options.skipPluginIds ?? []);
+    if (pluginResolved.ok) return pluginResolved;
+  }
+
+  // 试听及错误回退处理
   if (trialUrl && settings.player.allowTrialPlay) {
     return { ok: true, url: trialUrl, isTrial: true, provider: "trial" };
   }
   if (trialUrl) return { ok: false, errorCode: ErrorCode.NETEASE_TRIAL_DISABLED };
   if (officialErrorCode) return { ok: false, errorCode: officialErrorCode };
-  return pluginResolved;
+  if (pluginResolved) return pluginResolved;
+
+  return { ok: false, errorCode: ErrorCode.URL_RESOLVE_FAILED };
 };
 
 /**

--- a/src/services/download/source.ts
+++ b/src/services/download/source.ts
@@ -2,6 +2,7 @@ import type { Track } from "@shared/types/player";
 import type { QualityLevel } from "@/utils/quality";
 import { isPlatform } from "@shared/types/platform";
 import { useStreamingStore } from "@/stores/streaming";
+import { useSettingsStore } from "@/stores/settings";
 import { resolveByPlugin } from "@/services/audioSource";
 import { resolveNeteaseDownloadUrl } from "@/apis/song/netease";
 import { resolveQQMusicUrl } from "@/apis/song/qqmusic";
@@ -38,6 +39,16 @@ export const resolveDownloadSource = async (
       return null;
     }
   }
+
+  const settings = useSettingsStore();
+  const preferPlugin = settings.player.preferPluginSource;
+
+  // 若开启插件优先，先尝试音源插件
+  if (preferPlugin && isPlatform(track.source)) {
+    const res = await resolveByPlugin(track, level);
+    if (res.ok && !res.isTrial) return { url: res.url };
+  }
+
   // 官方接口
   if (track.source === "netease") {
     try {
@@ -56,8 +67,9 @@ export const resolveDownloadSource = async (
     const resolved = await resolveKugouUrl(track, level);
     if (resolved.available) return { url: resolved.url };
   }
-  // 其他播放源走插件
-  if (isPlatform(track.source)) {
+
+  // 若未开启插件优先，官方失败后兜底走插件
+  if (!preferPlugin && isPlatform(track.source)) {
     const res = await resolveByPlugin(track, level);
     if (res.ok && !res.isTrial) return { url: res.url };
   }

--- a/src/services/nextTrackPreloader.ts
+++ b/src/services/nextTrackPreloader.ts
@@ -44,6 +44,7 @@ const buildContextKey = (track: Track): string => {
     track.cueAudioPath ?? "",
     settings.player.songLevel,
     settings.player.allowTrialPlay,
+    settings.player.preferPluginSource,
     settings.preset.fuckDjMode,
     streaming.activeServerId ?? "",
     plugins.list
@@ -216,6 +217,7 @@ export const installNextTrackPreloadWatchers = (): void => {
       settings.player.preloadNextTrack,
       settings.player.songLevel,
       settings.player.allowTrialPlay,
+      settings.player.preferPluginSource,
       settings.preset.fuckDjMode,
       status.playIndex,
       status.fmMode,

--- a/src/settings/categories/player.ts
+++ b/src/settings/categories/player.ts
@@ -71,6 +71,12 @@ const playerCategory: SettingCategory = {
           defaultValue: false,
         },
         {
+          key: "preferPluginSource",
+          type: "switch",
+          binding: { store: "settings", path: "player.preferPluginSource" },
+          defaultValue: false,
+        },
+        {
           key: "preloadNextTrack",
           type: "switch",
           binding: { store: "settings", path: "player.preloadNextTrack" },

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -145,6 +145,7 @@ export const useSettingsStore = defineStore(
       reverseSpectrum: false,
       songLevel: "hq",
       allowTrialPlay: false,
+      preferPluginSource: false,
       timeFormat: "current-total",
       showProgressTooltip: true,
       showProgressLyric: false,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -238,6 +238,8 @@ export interface PlayerSettings {
   songLevel: QualityLevel;
   /** 允许完整音源不可用时播放试听片段 */
   allowTrialPlay: boolean;
+  /** 优先使用已启用的音源插件获取播放链接 */
+  preferPluginSource: boolean;
   /** 时间显示格式 */
   timeFormat: TimeFormat;
   /** 显示进度条悬浮信息 */


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

### 背景与动机
在安装了音源插件（如特定平台解析/解密插件）时，部分歌曲官方在线接口可能由于 VIP、未登录等原因获取到 试听 / 低音质内容，用户更期望直接使用第三方音源插件获取的音源直链。原逻辑中插件仅在官方接口解析失败后作为兜底使用，无法主动优先使用插件。

### 主要变更
1. **设置项新增**：
   - 在播放设置中增加「优先使用插件音源 (`preferPluginSource`)」配置项，默认关闭（保持既有行为兼容）。
   - 完善中英双语 i18n (`zh-CN.json` / `en-US.json`)。
2. **播放源解析链路调整** ([audioSource.ts](file:///e:/SPlayer-Next/src/services/audioSource.ts))：
   - 重构 `resolveOnlineUrl`，拆分出 `resolveOfficialOnlineUrl` 独立解析官方接口。
   - 当 `preferPluginSource` 开启时，优先调度 `resolveByPlugin` 解析直链；若插件未命中或仅返回试听，则回退至官方接口。
   - 未开启时保持原有逻辑（官方优先 -> 插件兜底 -> 试听回退）。
3. **下载源解析同步** ([download/source.ts](file:///e:/SPlayer-Next/src/services/download/source.ts))：
   - 同步 `preferPluginSource` 偏好，开启时优先尝试插件下载源。
4. **预加载缓存控制** ([nextTrackPreloader.ts](file:///e:/SPlayer-Next/src/services/nextTrackPreloader.ts))：
   - 将 `preferPluginSource` 纳入下一曲预加载的上下文构建键（`buildContextKey`）及响应式监听器列表，确保用户切换设置时预加载缓存正确失效和刷新。

## 测试情况

- **类型检查**：本地通过 `pnpm typecheck`（包含 `tsc` 和 `vue-tsc` 无任何报错）。
- **代码规范**：运行 `prettier --check`，所有变更文件格式均符合规范。
- **功能验证（Windows 11）**：
  - 未开启「优先使用插件音源」：行为与主分支一致，官方在线优先，插件作为失败兜底。
  - 开启「优先使用插件音源」：优先请求启用中的音源插件；若插件解析成功直接播放/下载插件源；若插件禁用或解析失败，平滑降级回退至官方接口。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向目标分支提交