### PR TITLE
fix: 修复托盘恢复后缩略图工具栏消失

### DIFF
--- a/electron/main/services/thumbar.ts
+++ b/electron/main/services/thumbar.ts
@@ -100,6 +100,8 @@ class ThumbarImpl implements Thumbar {
       clearTimeout(this.retryTimeout);
       this.retryTimeout = null;
     }
+    // 隐藏期间调用会污染 Electron 的按钮注册状态，待 show/restore 后统一下发
+    if (!this.win.isVisible()) return;
 
     this.like.icon = thumbarIcon(this.isLiked ? "like" : "unlike");
     this.like.tooltip = t(this.isLiked ? "removeFromLiked" : "addToLiked");


### PR DESCRIPTION
<!--
感谢贡献！提交前请确认：
1. 单个 PR 尽量只聚焦一个主要功能或修复，便于审查与回滚；多个不相关的改动请拆成多个 PR。
2. 请向 dev 分支提交。
3. 若改动中包含 AI 生成的代码，请务必自行完整测试与审阅，对其正确性负责，不要未经验证直接提交。
-->

## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

修复 Windows 下应用最小化到托盘后，在隐藏期间发生自动切歌或通过多媒体键切歌，再次唤出窗口时任务栏缩略图工具栏消失的问题。

窗口隐藏期间调用 `setThumbarButtons()` 会导致 Electron 内部的按钮注册状态异常。由于播放状态和喜欢状态的变化都会刷新缩略图工具栏，隐藏期间切歌可能触发该问题。

本次改动在统一的 Thumbar 渲染入口增加窗口可见性检查：

- 窗口隐藏或最小化时不再调用 `setThumbarButtons()`

## 关联 Issue

<!-- 如有关联，填 #编号；写 "Closes #编号" 可在合并时自动关闭对应 Issue -->

## 测试情况

测试环境：

- Windows 11
- SPlayer-Next-1.1.0-x64-portable.exe

复现步骤：

1. 将关闭按钮行为设置为“最小化到托盘”。
2. 开始播放音乐。
3. 将应用最小化到托盘。
4. 等待自动切换到下一首，或使用多媒体键切换到下一首。
5. 从托盘唤出应用。
6. 检查任务栏缩略图工具栏是否正常显示。

修复后确认问题已解决，缩略图工具栏能够正常显示，按钮状态与当前播放状态一致。本次改动仅影响 Windows 任务栏缩略图工具栏；未修改 macOS 和 Linux 平台行为。

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
