### PR TITLE
fix: 酷狗歌单/专辑超过 300 首被截断，分页拉取全量并补充分页测试

### DIFF
--- a/auto-eslint.mjs
+++ b/auto-eslint.mjs
@@ -188,7 +188,6 @@ export default {
     "useElementBounding": true,
     "useElementByPoint": true,
     "useElementHover": true,
-    "useElementOverflow": true,
     "useElementSize": true,
     "useElementVisibility": true,
     "useEventBus": true,

--- a/electron/main/apis/kugou/core/pagination.test.ts
+++ b/electron/main/apis/kugou/core/pagination.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fetchAllPages, type PagedResponse } from "./pagination";
+
+interface Song {
+  hash: string;
+}
+
+/** 生成 n 首伪歌曲数据 */
+const makeSongs = (n: number, offset = 0): Song[] =>
+  Array.from({ length: n }, (_, i) => ({ hash: `hash${offset + i}` }));
+
+/**
+ * 构造按页返回的 requestPage 替身
+ * @param pages - 每页的 { total, count, offset } 描述（下标 0 = 第 1 页）
+ * @param failPages - 需要抛错的页码集合
+ */
+const createPagedRequest = (
+  pages: Array<{ total?: number; count: number; offset: number }>,
+  failPages: number[] = [],
+) => {
+  const calls: number[] = [];
+  const requestPage = async (page: number): Promise<PagedResponse<Song>> => {
+    calls.push(page);
+    if (failPages.includes(page)) throw new Error("timeout");
+    const entry = pages[page - 1];
+    if (!entry) return { data: { info: [], total: pages[0]?.total ?? 0 } };
+    return { data: { info: makeSongs(entry.count, entry.offset), total: entry.total } };
+  };
+  return { calls, requestPage };
+};
+
+describe("酷狗分页全量拉取", () => {
+  it("不足一页时不翻页，直接返回", async () => {
+    const { calls, requestPage } = createPagedRequest([{ total: 120, count: 120, offset: 0 }]);
+    const songs = await fetchAllPages<Song>(requestPage);
+
+    assert.equal(songs.length, 120);
+    assert.deepEqual(calls, [1], "只应请求第一页");
+  });
+
+  it("超过一页时并发补拉剩余页并按顺序拼接", async () => {
+    // 833 首：第 1 页 300 + 第 2 页 300 + 第 3 页 233
+    const { calls, requestPage } = createPagedRequest([
+      { total: 833, count: 300, offset: 0 },
+      { total: 833, count: 300, offset: 300 },
+      { total: 833, count: 233, offset: 600 },
+    ]);
+    const songs = await fetchAllPages<Song>(requestPage);
+
+    assert.equal(songs.length, 833);
+    assert.deepEqual(calls.sort(), [1, 2, 3], "应请求全部 3 页");
+    // 拼接顺序：第 301 首应来自第 2 页的 offset
+    assert.equal(songs[300]?.hash, "hash300");
+    assert.equal(songs[832]?.hash, "hash832");
+  });
+
+  it("整页数歌单（无零头页）也正确翻页", async () => {
+    // 600 首 = 2 页整
+    const { calls, requestPage } = createPagedRequest([
+      { total: 600, count: 300, offset: 0 },
+      { total: 600, count: 300, offset: 300 },
+    ]);
+    const songs = await fetchAllPages<Song>(requestPage);
+
+    assert.equal(songs.length, 600);
+    assert.equal(calls.length, 2);
+  });
+
+  it("个别补拉页失败时容错返回已拿到的部分", async () => {
+    // 833 首但第 2 页超时：返回 300 + 233 = 533 首，不整体失败
+    const { requestPage } = createPagedRequest(
+      [
+        { total: 833, count: 300, offset: 0 },
+        { total: 833, count: 300, offset: 300 },
+        { total: 833, count: 233, offset: 600 },
+      ],
+      [2],
+    );
+    const songs = await fetchAllPages<Song>(requestPage);
+
+    assert.equal(songs.length, 533);
+    assert.equal(songs[300]?.hash, "hash600", "缺口后应接第 3 页数据");
+  });
+
+  it("第一页失败时抛错（由上层决定降级）", async () => {
+    const { requestPage } = createPagedRequest([{ total: 300, count: 300, offset: 0 }], [1]);
+    await assert.rejects(() => fetchAllPages<Song>(requestPage), /timeout/);
+  });
+
+  it("接口 total 异常巨大时按 MAX_SONGS 上限封顶", async () => {
+    let maxPage = 0;
+    const requestPage = async (page: number): Promise<PagedResponse<Song>> => {
+      maxPage = Math.max(maxPage, page);
+      return { data: { info: makeSongs(300, (page - 1) * 300), total: 100000 } };
+    };
+    const songs = await fetchAllPages<Song>(requestPage);
+
+    // 5000 上限：第 1 页 300 + 补拉 4700 = 5000，共 17 页后停止
+    assert.equal(songs.length, 5000);
+    assert.equal(maxPage, 17);
+  });
+
+  it("第一页未返回 total 时按本页数量收工（不盲翻）", async () => {
+    const { calls, requestPage } = createPagedRequest([
+      { total: undefined, count: 300, offset: 0 },
+    ]);
+    const songs = await fetchAllPages<Song>(requestPage);
+
+    assert.equal(songs.length, 300);
+    assert.deepEqual(calls, [1], "无 total 时不应继续翻页");
+  });
+});

--- a/electron/main/apis/kugou/core/pagination.ts
+++ b/electron/main/apis/kugou/core/pagination.ts
@@ -1,0 +1,41 @@
+/**
+ * KG 分页拉取辅助
+ *
+ * 酷狗歌单/专辑接口按 page 分页返回，此模块封装「先取第一页拿 total，
+ * 再并发补拉剩余页」的全量拉取逻辑，供 playlist / album 模块复用。
+ */
+
+/** special/song 单页条数（保持接口示例值，翻页逻辑负责取全量） */
+export const SONG_PAGESIZE = 300;
+
+/** 单个歌单/专辑最多拉取的歌曲数，防止异常 total 无限翻页 */
+export const MAX_SONGS = 5000;
+
+/** 分页响应的 data 结构 */
+export interface PagedResponse<T> {
+  data?: { info?: T[]; total?: number };
+}
+
+/**
+ * 拉取全量分页数据：先取第一页拿 total，再并发补拉剩余页
+ * @param requestPage - 页码 → 该页响应的请求函数
+ * @returns 全量条目；个别补拉页失败时返回已拿到的部分
+ */
+export const fetchAllPages = async <T>(
+  requestPage: (page: number) => Promise<PagedResponse<T>>,
+): Promise<T[]> => {
+  const first = await requestPage(1);
+  const firstItems = first.data?.info ?? [];
+  const total = Math.min(first.data?.total ?? firstItems.length, MAX_SONGS);
+  const restCount = total - firstItems.length;
+  if (restCount <= 0) return firstItems;
+
+  const pages = Math.ceil(restCount / SONG_PAGESIZE);
+  const rest = await Promise.all(
+    Array.from({ length: pages }, (_, i) =>
+      requestPage(i + 2).catch(() => ({ data: {} as never })),
+    ),
+  );
+  const merged = [...firstItems, ...rest.flatMap((r) => r.data?.info ?? [])];
+  return merged.slice(0, total);
+};

--- a/electron/main/apis/kugou/modules/album.ts
+++ b/electron/main/apis/kugou/modules/album.ts
@@ -7,6 +7,7 @@
  */
 
 import { decodeName, fillCover } from "../core/config";
+import { fetchAllPages } from "../core/pagination";
 import { kgGatewayRequest, kgRequest } from "../core/request";
 import type { KGModule, KGSong, Quality } from "../core/types";
 
@@ -259,18 +260,36 @@ const resolveAlbumId = async (idOrName: string): Promise<string> => {
   return idOrName;
 };
 
+/**
+ * 拉取专辑全量歌曲（mobilecdn 通道）：复用分页拉取，第一页失败返回空数组
+ * @param albumId - 专辑 albumid
+ */
+const fetchAllMobileAlbumSongs = async (albumId: string): Promise<MobileAlbumSong[]> => {
+  const requestPage = async (page: number) => {
+    const res = await kgRequest<{
+      data?: { info?: MobileAlbumSong[]; total?: number };
+    }>(
+      `http://mobilecdn.kugou.com/api/v3/album/song?albumid=${encodeURIComponent(albumId)}&page=${page}&pagesize=300&format=json`,
+    ).catch(() => ({ data: undefined }));
+    return res as PagedResponseLike<MobileAlbumSong>;
+  };
+  return fetchAllPages<MobileAlbumSong>(requestPage);
+};
+
+/** mobilecdn 分页响应的宽松结构（info/total 均可缺省） */
+interface PagedResponseLike<T> {
+  data?: { info?: T[]; total?: number };
+}
+
 const loadAlbumFromMobile = async (albumId: string) => {
-  const [infoRes, songsRes] = await Promise.all([
+  const [infoRes, rawSongs] = await Promise.all([
     kgRequest<{ data?: MobileAlbumInfo }>(
       `http://mobilecdn.kugou.com/api/v3/album/info?albumid=${encodeURIComponent(albumId)}&format=json`,
     ).catch(() => ({ data: undefined })),
-    kgRequest<{ data?: { info?: MobileAlbumSong[]; total?: number } }>(
-      `http://mobilecdn.kugou.com/api/v3/album/song?albumid=${encodeURIComponent(albumId)}&page=1&pagesize=300&format=json`,
-    ).catch(() => ({ data: undefined })),
+    fetchAllMobileAlbumSongs(albumId),
   ]);
 
   const info = infoRes.data ?? {};
-  const rawSongs = songsRes.data?.info ?? [];
   const cover = fillCover(info.imgurl, 300);
   const coverOriginal = fillCover(info.imgurl, 480);
   const songs = rawSongs.map((s) => normalizeMobileAlbumSong(s, info.imgurl));
@@ -292,9 +311,32 @@ const loadAlbumFromMobile = async (albumId: string) => {
       : [],
     publishTime: info.publishtime,
     description: info.intro,
-    total: info.songcount ?? songsRes.data?.total ?? songs.length,
+    total: songs.length,
     songs,
   };
+};
+
+/**
+ * 拉取专辑全量歌曲（网关 /v1/album_audio/lite 通道）：复用分页拉取
+ * @param id - 专辑 albumid
+ * @returns 全量歌曲原始数据；接口异常时抛错由上层降级 mobilecdn
+ */
+const fetchAllGatewayAlbumSongs = async (id: string): Promise<RawAlbumSongEntry[]> => {
+  // 网关返回的 data 可能是歌曲数组本身或 { songs, total } 包装，适配成分页结构
+  const requestPage = async (page: number) => {
+    const res = await kgGatewayRequest<{
+      data?: { songs?: RawAlbumSongEntry[]; total?: number } | RawAlbumSongEntry[];
+    }>("/v1/album_audio/lite", {
+      method: "POST",
+      data: { album_id: id, page, pagesize: 300 },
+      headers: { "x-router": "openapi.kugou.com", "kg-tid": "255" },
+    });
+    const list = Array.isArray(res.data) ? res.data : (res.data?.songs ?? []);
+    const total = Array.isArray(res.data) ? undefined : res.data?.total;
+    return { data: { info: list, total } };
+  };
+
+  return fetchAllPages<RawAlbumSongEntry>(requestPage);
 };
 
 const album: KGModule = async (params) => {
@@ -305,7 +347,7 @@ const album: KGModule = async (params) => {
 
   // 优先通过网关请求
   try {
-    const [detailRes, songsRes] = await Promise.all([
+    const [detailRes, rawSongs] = await Promise.all([
       kgGatewayRequest<{ data?: RawAlbumDetail[] }>("/kmr/v2/albums", {
         method: "POST",
         data: {
@@ -315,24 +357,14 @@ const album: KGModule = async (params) => {
         },
         headers: { "x-router": "openapi.kugou.com", "kg-tid": "255" },
       }),
-      kgGatewayRequest<{
-        data?: { songs?: RawAlbumSongEntry[]; total?: number } | RawAlbumSongEntry[];
-      }>("/v1/album_audio/lite", {
-        method: "POST",
-        data: { album_id: id, page: 1, pagesize: 300 },
-        headers: { "x-router": "openapi.kugou.com", "kg-tid": "255" },
-      }),
+      fetchAllGatewayAlbumSongs(id),
     ]);
 
     const detail = detailRes.data?.[0] ?? {};
     const cover = fillCover(detail.sizable_cover, 300);
     const coverOriginal = fillCover(detail.sizable_cover, 480);
 
-    const rawSongs: RawAlbumSongEntry[] = Array.isArray(songsRes.data)
-      ? songsRes.data
-      : (songsRes.data?.songs ?? []);
     const songs = rawSongs.map((item) => normalizeAlbumSong(item, detail.sizable_cover));
-
     const authors = detail.authors ?? [];
     const artistName =
       detail.author_name ||
@@ -356,7 +388,7 @@ const album: KGModule = async (params) => {
       })),
       publishTime: detail.publish_date,
       description: detail.intro,
-      total: detail.songcount ?? songs.length,
+      total: songs.length,
       songs,
     };
   } catch {

--- a/electron/main/apis/kugou/modules/playlist.ts
+++ b/electron/main/apis/kugou/modules/playlist.ts
@@ -7,6 +7,7 @@
  */
 
 import { decodeName, fillCover } from "../core/config";
+import { fetchAllPages, type PagedResponse } from "../core/pagination";
 import { kgRequest } from "../core/request";
 import type { KGModule, KGSong, Quality } from "../core/types";
 
@@ -132,17 +133,20 @@ const playlist: KGModule = async (params) => {
   const id = String(params.id ?? params.specialid ?? params.special_id ?? "");
   if (!id) return { code: 400, message: "id required" };
 
-  const [infoRes, songsRes] = await Promise.all([
+  const [infoRes, rawSongs] = await Promise.all([
     kgRequest<{ data?: RawSpecialInfo }>(
       `http://mobilecdn.kugou.com/api/v3/special/info?specialid=${encodeURIComponent(id)}&format=json`,
     ),
-    kgRequest<{ data?: { info?: RawSpecialSong[]; total?: number } }>(
-      `http://mobilecdn.kugou.com/api/v3/special/song?specialid=${encodeURIComponent(id)}&page=1&pagesize=300&format=json`,
+    fetchAllPages<RawSpecialSong>(async (page) =>
+      kgRequest<PagedResponse<RawSpecialSong>>(
+        `http://mobilecdn.kugou.com/api/v3/special/song?specialid=${encodeURIComponent(id)}&page=${page}&pagesize=300&format=json`,
+        // mobilecdn 波动大（单请求实测可达 15s+），默认 8s 超时对 300 首/页的大响应偏紧
+        { signal: AbortSignal.timeout(30_000) },
+      ),
     ),
   ]);
 
   const info = infoRes.data ?? {};
-  const rawSongs = songsRes.data?.info ?? [];
 
   const cover = fillCover(info.imgurl, 300);
   const coverOriginal = fillCover(info.imgurl, 480);
@@ -157,7 +161,7 @@ const playlist: KGModule = async (params) => {
     cover,
     coverOriginal,
     playCount: info.playcount ?? 0,
-    total: info.songcount ?? songsRes.data?.total ?? songs.length,
+    total: songs.length,
     songs,
   };
 };


### PR DESCRIPTION
## 改动类型

- [x] 缺陷修复（fix）

## 是否包含破坏性变更

- [ ] 否

改动说明

修复 #247。

问题：酷狗歌单/专辑歌曲数超过 300 时，客户端只请求 page=1&pagesize=300 单页就收工，其余歌曲静默丢失。而酷狗 special/song、album/song、/v1/album_audio/lite 接口均支持分页（实测验证）。

修复：新增 electron/main/apis/kugou/core/pagination.ts 提供 fetchAllPages——先取第一页拿 total，再并发补拉剩余页拼接。三处调用点（歌单、专辑 mobilecdn 通道、专辑网关通道）统一改走该函数。

设计要点：

- pagesize 保持 300 不变，只补翻页逻辑，改动最小
- 剩余页并发拉取（Promise.all），大歌单总耗时 ≈ 两次往返
- 单页失败容错（返回空页），个别页超时不影响整体
- MAX_SONGS = 5000 上限防御异常 total，翻页后 slice(0, total) 精确封顶
- 无 total 时不盲翻，按第一页数量收工
- 歌单翻页请求超时放宽至 30s（mobilecdn 实测单请求可达 15s+，默认 8s 偏紧）
- 返回的 total 改为实际取回的 songs.length，界面数字与真实数据一致

关联 Issue

Closes #247

测试情况

- 新增单元测试 pagination.test.ts 覆盖 7 个场景：不足一页不翻页 / 多页拼接顺序 / 整页数翻页 / 单页失败容错 / 第一页失败抛错 / 异常 total 封顶 / 无 total 不盲翻
- pnpm test:node：41/41 通过；pnpm test:web：57/57 通过；pnpm typecheck、pnpm lint、pnpm format 均通过
- 真实接口回归：歌单 8540649（832+ 首）全量取回，第 301 首（接口第二页首条）在列表中可搜索
- 实机验证（Windows 11，dev 构建）：打开测试歌单显示总数与酷狗服务端实时数据一致
- 平台覆盖：改动仅涉主进程网络层，平台无关；实机验证为 Windows
## 自查清单

- [x] 本 PR 只包含一个主要功能 / 修复，没有夹带无关改动
- [x] 已在本地完整测试通过；AI 生成的代码同样自行测试并审阅过，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交