### PR TITLE
fix: 根据双行显示状态隐藏任务栏歌词翻译选项

### DIFF
--- a/src/settings/categories/externalLyric.ts
+++ b/src/settings/categories/externalLyric.ts
@@ -384,6 +384,7 @@ const taskbarLyricSection: SettingSection = {
       type: "switch",
       binding: { store: "settings", path: "system.taskbarLyric.showTranslation" },
       defaultValue: true,
+      visible: () => useSettingsStore().system.taskbarLyric.doubleLine === true,
     },
   ],
 };


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

设置-外部歌词-任务栏歌词：单行模式（即关闭双行显示选项）下的“显示翻译”选项不会产生实际效果，容易让用户误解。此PR尝试修改为仅在开启“双行显示”时才会显示翻译选项。

本次改动复用 Setting schema 现有的 `visible()` 条件显示机制：

- 开启“双行显示”时显示“显示翻译”选项；
- 关闭“双行显示”时隐藏“显示翻译”选项；
- 仅控制设置项的 UI 可见性，不修改或重置原有 `showTranslation` 配置值；
- 不涉及歌词渲染逻辑、配置结构、store、类型或 i18n。

## 关联 Issue

暂无

## 测试情况

- [x] `pnpm format`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Windows 手动验证
  - 开启“双行显示”后，“显示翻译”正常出现；
  - 关闭“双行显示”后，“显示翻译”正常隐藏；
  - 重新开启“双行显示”后，原有翻译开关状态保持不变。


## 截图 / 录屏

开启双行显示，此时“显示翻译”渲染
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/4565dc6c-cfa5-4315-9303-46f6863215b3" />
关闭双行显示，此时“显示翻译”不渲染
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/7cae5a5e-ce0b-4d58-bd2b-868cde7e1c3d" />

反复重启双行显示，确认“显示翻译”选项不会被重置
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/93134a72-2a43-4cf0-bc21-ab03afe67f46" />
（启用“显示翻译”，并确认开关双行显示不会影响该选项的值）
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/5c91ca1c-1b38-40e6-8491-6d48c9a46d6b" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ddf16b22-74b8-486c-83c6-98295aee69ae" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/688c1f4e-a068-45be-8dbe-55b63c38a961" />

## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交
