### PR TITLE
fix: 修复任务栏歌词窗口偶尔漂移到屏幕顶部

### DIFF
--- a/electron/main/window/taskbarLyric.ts
+++ b/electron/main/window/taskbarLyric.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen } from "electron";
 import { join } from "path";
 import { is } from "@electron-toolkit/utils";
 import { createWindow } from "./create";
+import { resolveEmbedAction } from "./taskbarLyricEmbed";
 import { loadNativeModule } from "@main/utils/nativeLoader";
 import { broadcast } from "@main/utils/broadcast";
 import { setTrayTaskbarLyric } from "@main/services/tray";
@@ -52,6 +53,10 @@ interface ActiveWindowRegion {
 let activeWindowRegion: ActiveWindowRegion | null = null;
 let contentWidth: number | null = null;
 
+/** 上次成功嵌入任务栏时的窗口 HWND，null 表示尚未完成首次嵌入 */
+let embeddedHwnd: number | null = null;
+let embedWatchTimer: ReturnType<typeof setInterval> | null = null;
+
 /** 从设置读取当前歌词宽度（Win10 据此从 tasklist 划空间，Win11 忽略） */
 const resolveLyricWidth = (): number => {
   const width = store.get("taskbarLyric.maxWidth");
@@ -74,6 +79,25 @@ const INITIAL_HEIGHT = 200;
  * 视觉很糟，直接隐藏窗口；空间回升后再 show
  */
 const MIN_LYRIC_WIDTH_DIP = 120;
+
+/**
+ * 嵌入健康校验间隔
+ *
+ * 窗口的位置坐标是「相对任务栏」的，父关系被外部解除后同一组坐标会按屏幕坐标解释，
+ * 窗口停在屏幕顶部且不会自行恢复，因此需要持续校验
+ */
+const EMBED_CHECK_INTERVAL_MS = 500;
+
+/**
+ * 读取窗口的 HWND
+ * @param win - 目标窗口
+ * @returns HWND 数值；超出 JS Number 安全整数范围时返回 null
+ */
+const readHwnd = (win: BrowserWindow): number | null => {
+  // Windows 上 HWND 可能是 64 位值，先按 BigInt 读取，避免直接转 number 产生静默精度丢失
+  const value = win.getNativeWindowHandle().readBigUInt64LE(0);
+  return value > BigInt(Number.MAX_SAFE_INTEGER) ? null : Number(value);
+};
 
 /** 获取任务栏歌词窗口实例（未创建或已销毁时返回 null） */
 export const getTaskbarLyricWindow = (): BrowserWindow | null =>
@@ -328,19 +352,17 @@ export const createTaskbarLyricWindow = (): BrowserWindow | null => {
     const mod = nativeModule;
     if (!win || !svc || !mod) return;
 
-    // Windows 上 HWND 可能是 64 位值，先保留为 BigInt，避免直接转成 number 产生静默精度丢失
-    const hwndPtrBigInt = win.getNativeWindowHandle().readBigUInt64LE(0);
-    if (hwndPtrBigInt > BigInt(Number.MAX_SAFE_INTEGER)) {
-      taskbarLog.error(
-        `嵌入窗口失败：hwnd=${hwndPtrBigInt.toString()} 超出 JS Number 安全整数范围`,
-      );
+    const hwndPtr = readHwnd(win);
+    if (hwndPtr === null) {
+      taskbarLog.error("嵌入窗口失败：HWND 超出 JS Number 安全整数范围");
       return;
     }
-    const hwndPtr = Number(hwndPtrBigInt);
     taskbarLog.info(`嵌入窗口 hwnd=${hwndPtr}`);
     svc.embedWindowByPtr(hwndPtr);
+    embeddedHwnd = hwndPtr;
     svc.update(resolveLyricWidth());
     startWatchers(mod);
+    startEmbedWatch();
     taskbarCreatedWatcher = tryStart(
       "TaskbarCreatedWatcher",
       () => new mod.TaskbarCreatedWatcher(onExplorerRestart),
@@ -352,6 +374,8 @@ export const createTaskbarLyricWindow = (): BrowserWindow | null => {
     firstLayoutDone = false;
     activeWindowRegion = null;
     contentWidth = null;
+    embeddedHwnd = null;
+    stopEmbedWatch();
     cleanupWatchers();
     setTrayTaskbarLyric(false);
     broadcast("taskbarLyric:visibilityChange", false);
@@ -394,4 +418,48 @@ export const toggleTaskbarLyricWindow = (): boolean => {
 /** 触发一次布局重算（配置变更后调用） */
 export const applyTaskbarLyricLayout = (): void => {
   service?.update(resolveLyricWidth());
+};
+
+/**
+ * 嵌入失效后的自愈：先隐藏避免残影，再重新附着到任务栏并重放布局
+ * @param win - 任务栏歌词窗口
+ * @param hwnd - 需要重新嵌入的 HWND
+ */
+const recoverEmbed = (win: BrowserWindow, hwnd: number): void => {
+  const svc = service;
+  if (!svc) return;
+  win.hide();
+  svc.embedWindowByPtr(hwnd);
+  embeddedHwnd = hwnd;
+  applyTaskbarLyricLayout();
+};
+
+/** 校验窗口是否仍嵌在任务栏上，失效则自愈 */
+const verifyEmbed = (): void => {
+  const win = getTaskbarLyricWindow();
+  const mod = nativeModule;
+  if (!win || !mod || embeddedHwnd === null) return;
+
+  const state = mod.probeWindow(embeddedHwnd);
+  // HWND 已失效时不对窗口做任何操作（重建窗口不在本次范围内）
+  if (!state.alive) return;
+
+  const hwnd = readHwnd(win);
+  if (hwnd === null) return;
+
+  const action = resolveEmbedAction(state, hwnd, embeddedHwnd);
+  if (action === "reattach" || action === "reembed") recoverEmbed(win, hwnd);
+};
+
+/** 启动嵌入健康校验 */
+const startEmbedWatch = (): void => {
+  if (embedWatchTimer !== null) return;
+  embedWatchTimer = setInterval(verifyEmbed, EMBED_CHECK_INTERVAL_MS);
+};
+
+/** 停止嵌入健康校验 */
+const stopEmbedWatch = (): void => {
+  if (embedWatchTimer === null) return;
+  clearInterval(embedWatchTimer);
+  embedWatchTimer = null;
 };

--- a/electron/main/window/taskbarLyricEmbed.test.ts
+++ b/electron/main/window/taskbarLyricEmbed.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveEmbedAction } from "./taskbarLyricEmbed";
+
+describe("resolveEmbedAction", () => {
+  it("尚未完成首次嵌入时不动作", () => {
+    assert.equal(resolveEmbedAction({ alive: true, embedded: true }, 11, null), "idle");
+  });
+
+  it("HWND 已失效时不动作（避免对失效窗口做任何操作）", () => {
+    assert.equal(resolveEmbedAction({ alive: false, embedded: false }, 11, 11), "idle");
+  });
+
+  it("父关系被摘除时重新附着", () => {
+    assert.equal(resolveEmbedAction({ alive: true, embedded: false }, 11, 11), "reattach");
+  });
+
+  it("窗口被重建（HWND 变化）时重新嵌入", () => {
+    assert.equal(resolveEmbedAction({ alive: true, embedded: true }, 22, 11), "reembed");
+  });
+
+  it("HWND 变化且父关系同时失效时优先重新嵌入", () => {
+    assert.equal(resolveEmbedAction({ alive: true, embedded: false }, 22, 11), "reembed");
+  });
+
+  it("一切正常时不动作", () => {
+    assert.equal(resolveEmbedAction({ alive: true, embedded: true }, 11, 11), "healthy");
+  });
+});

--- a/electron/main/window/taskbarLyricEmbed.ts
+++ b/electron/main/window/taskbarLyricEmbed.ts
@@ -1,0 +1,24 @@
+/** 嵌入健康校验需要执行的动作 */
+export type EmbedAction = "idle" | "healthy" | "reattach" | "reembed";
+
+/**
+ * 根据原生探测结果决定是否需要自愈
+ *
+ * 任务栏歌词窗口的坐标是「相对任务栏」的（y=0 即任务栏顶边），父关系一旦失效，
+ * 同一组坐标会被当作屏幕坐标解释，窗口会停在屏幕顶部且不会自行恢复
+ * @param state - 原生探测结果（alive: HWND 是否仍有效；embedded: 是否仍挂在任务栏上）
+ * @param currentHwnd - 窗口当前的 HWND
+ * @param embeddedHwnd - 上次嵌入时记录的 HWND，null 表示尚未完成首次嵌入
+ * @returns 需要执行的动作
+ */
+export const resolveEmbedAction = (
+  state: { alive: boolean; embedded: boolean },
+  currentHwnd: number,
+  embeddedHwnd: number | null,
+): EmbedAction => {
+  if (embeddedHwnd === null) return "idle";
+  // HWND 已失效：不对窗口做任何操作，交给 explorer 重启路径处理
+  if (!state.alive) return "idle";
+  if (currentHwnd !== embeddedHwnd) return "reembed";
+  return state.embedded ? "healthy" : "reattach";
+};

--- a/native/taskbar-lyric/index.d.ts
+++ b/native/taskbar-lyric/index.d.ts
@@ -44,6 +44,14 @@ export interface JsAvailableSpace {
   right: JsRect
 }
 
+/** 窗口的嵌入状态 */
+export interface JsEmbedState {
+  /** HWND 是否仍然有效 */
+  alive: boolean
+  /** 是否仍嵌在 explorer 的任务栏上 */
+  embedded: boolean
+}
+
 export interface JsExtraLayoutInfo {
   /** "win10" | "win11" */
   systemType: string
@@ -63,3 +71,13 @@ export interface JsTaskbarLayout {
   space: JsAvailableSpace
   extra: JsExtraLayoutInfo
 }
+
+/**
+ * 探测窗口是否仍挂在 explorer 的任务栏上
+ *
+ * 任务栏歌词窗口的位置坐标是「相对任务栏」的（y=0 即任务栏顶边），父关系一旦被解除，
+ * 同一组坐标会被按屏幕坐标解释，窗口就停在屏幕顶部且不会自行恢复
+ * @param hwnd_ptr - Electron BrowserWindow 的 native handle
+ * @returns 窗口是否存活、是否仍嵌在任务栏上
+ */
+export declare function probeWindow(hwndPtr: number): JsEmbedState

--- a/native/taskbar-lyric/src/lib.rs
+++ b/native/taskbar-lyric/src/lib.rs
@@ -8,7 +8,10 @@ use napi::{
     threadsafe_function::{ThreadsafeFunctionCallMode, UnknownReturnValue},
 };
 use napi_derive::napi;
-use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::IsWindow};
+use windows::Win32::{
+    Foundation::HWND,
+    UI::WindowsAndMessaging::{GA_PARENT, GetAncestor, IsWindow},
+};
 
 /// 任务列表和歌词之间的微小间距
 pub const GAP: i32 = 10;
@@ -100,6 +103,41 @@ pub(crate) fn take_valid_hwnd(hwnd_ptr: usize) -> Option<HWND> {
     } else {
         warn!("无效 HWND (0x{hwnd_ptr:x})，跳过");
         None
+    }
+}
+
+/// 窗口的嵌入状态
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct JsEmbedState {
+    /// HWND 是否仍然有效
+    pub alive: bool,
+    /// 是否仍嵌在 explorer 的任务栏上
+    pub embedded: bool,
+}
+
+/// 探测窗口是否仍挂在 explorer 的任务栏上
+///
+/// 任务栏歌词窗口的位置坐标是「相对任务栏」的（y=0 即任务栏顶边），父关系一旦被解除，
+/// 同一组坐标会被按屏幕坐标解释，窗口就停在屏幕顶部且不会自行恢复
+/// @param hwnd_ptr - Electron BrowserWindow 的 native handle
+/// @returns 窗口是否存活、是否仍嵌在任务栏上
+#[napi]
+pub fn probe_window(hwnd_ptr: f64) -> JsEmbedState {
+    let Some(hwnd) = take_valid_hwnd(hwnd_ptr as usize) else {
+        return JsEmbedState {
+            alive: false,
+            embedded: false,
+        };
+    };
+
+    // SAFETY: hwnd 已由 take_valid_hwnd 校验有效
+    let embedded = utils::find_taskbar_hwnd()
+        .is_some_and(|taskbar| unsafe { GetAncestor(hwnd, GA_PARENT) == taskbar });
+
+    JsEmbedState {
+        alive: true,
+        embedded,
     }
 }
 


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（feat）
- [x] 缺陷修复（fix）
- [ ] 重构 / 优化（不改变对外行为）
- [ ] 文档（docs）
- [ ] 其他（请在「改动说明」中注明）

## 是否包含破坏性变更

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

- [ ] 是（请在「改动说明」中详细描述）
- [x] 否

## 改动说明

修复任务栏歌词窗口偶尔「漂到屏幕顶部」并永久停在那里的问题。

**现象**：开启任务栏歌词后，歌词窗口偶尔会出现在屏幕顶部（水平位置与宽高仍是任务栏空余区域那组值），且不会再回到任务栏，只有把「任务栏歌词」开关关开一次才恢复。

**根因**：歌词窗口靠 `SetParent` 嵌入任务栏，其位置坐标是「相对任务栏」的——原生侧返回的布局矩形里 `y` 恒为 0（即任务栏顶边），`applyLayout` 原样交给 `win.setBounds()`。父关系一旦被外部解除（例如 `SetParent(hwnd, NULL)`），同一组数字会被按**屏幕坐标**解释，窗口就精确落在屏幕顶部；而此后每次布局仍然传 `y=0`，等于反复把它按在顶部，因此不会自行恢复。

原实现只在窗口 `ready-to-show` 时嵌入一次，之后没有任何地方校验「窗口是否还挂在任务栏上」，所以一旦失效就是永久的。

**改动**：
- `native/taskbar-lyric/src/lib.rs`：新增 `probeWindow(hwndPtr) -> { alive, embedded }`——用 `IsWindow` 判断句柄是否仍有效，用 `GetAncestor(GA_PARENT)` 与当前 explorer 的 `Shell_TrayWnd` 比对判断是否仍嵌在任务栏上；
- `electron/main/window/taskbarLyric.ts`：记住嵌入时的 HWND，每 500ms 校验一次；父关系被解除则「隐藏 → 重新 `SetParent` → 重放布局（`setBounds` + `setShape`）」，HWND 变化时用新句柄重新嵌入；HWND 已失效（explorer 重启）时不对窗口做任何操作；
- `electron/main/window/taskbarLyricEmbed.ts`（新增）：判定逻辑抽为纯函数并补充单测。

**范围**：不改变窗口样式与嵌入方式、不引入新日志、不处理「窗口被销毁后重建」（explorer 重启后的恢复维持现状）。

## 关联 Issue

无

## 测试情况

**平台**：Windows 11 25H2（内部版本 26200）

1. **单元测试**：新增 6 条，覆盖判定全部分支；`pnpm test` 通过（node 40/40、vitest 57/57）。
2. **手动验收**：对歌词窗口执行 `SetParent(hwnd, NULL)`，模拟「父关系被外部解除」这一失效场景：

| | 修复前 | 修复后 |
|---|---|---|
| 注入后 | 20 秒内始终停在屏幕顶部（y=0），应用无任何反应 | **1 秒内自行回到任务栏** |

   - 连续注入 6 次，每次均在 1 秒内自愈；窗口句柄与位置尺寸保持一致（`rect=(715,816) 570×48`，父窗口 = `Shell_TrayWnd`）；
   - 自愈后截图确认歌词正文 / 翻译 / 封面在任务栏中**正常渲染**，排除「位置正确但画面为空」的情况。
3. **静态检查**：`pnpm format`、`pnpm typecheck`（node + web）、`pnpm lint`、`cargo test --workspace` 均通过。

<details>
<summary>复现/验收方法（Windows，普通权限即可）</summary>

该问题依赖「窗口父关系被外部解除」这一时机，我也是使用过程偶然发生过几次，靠碰运气很难复现，因此用下面的片段主动制造该场景：找到嵌在任务栏里的歌词窗口，把它从任务栏上摘下来（`SetParent(hwnd, NULL)`），即可在修复前稳定复现「跳到屏幕顶部且不再恢复」，修复后应在 1 秒内自愈。

```powershell
Add-Type -TypeDefinition @'
using System; using System.Text; using System.Runtime.InteropServices;
public class TbTest {
  public delegate bool E(IntPtr h, IntPtr l);
  [DllImport("user32.dll")] public static extern bool EnumWindows(E cb, IntPtr l);
  [DllImport("user32.dll")] public static extern bool EnumChildWindows(IntPtr p, E cb, IntPtr l);
  [DllImport("user32.dll")] public static extern IntPtr SetParent(IntPtr c, IntPtr p);
  [DllImport("user32.dll")] public static extern IntPtr GetAncestor(IntPtr h, uint f);
  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowTextW(IntPtr h, StringBuilder s, int n);
  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassNameW(IntPtr h, StringBuilder s, int n);
  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L,T,R,B; }
  static string Txt(IntPtr h){ var s=new StringBuilder(256); GetWindowTextW(h,s,256); return s.ToString(); }
  static string Cls(IntPtr h){ var s=new StringBuilder(256); GetClassNameW(h,s,256); return s.ToString(); }
  public static IntPtr Widget() {
    IntPtr tb = IntPtr.Zero;
    EnumWindows((h,l) => { if (Cls(h)=="Shell_TrayWnd") { tb=h; return false; } return true; }, IntPtr.Zero);
    IntPtr w = IntPtr.Zero;
    if (tb != IntPtr.Zero) EnumChildWindows(tb, (c,l) => {
      if (Cls(c)=="Chrome_WidgetWin_1" && Txt(c)=="Taskbar Lyric") { w=c; return false; } return true; }, IntPtr.Zero);
    return w;
  }
  public static string State() {
    var w = Widget(); RECT r; GetWindowRect(w, out r);
    return string.Format("hwnd={0} rect=({1},{2}) {3}x{4} parent={5}[{6}]", w, r.L, r.T, r.R-r.L, r.B-r.T, GetAncestor(w,1), Cls(GetAncestor(w,1)));
  }
  public static void Detach() { SetParent(Widget(), IntPtr.Zero); }
}
'@ -ErrorAction Stop
"注入前: $([TbTest]::State())"
[TbTest]::Detach()                     # 制造失效：父关系被解除
Start-Sleep -Seconds 3
"注入后: $([TbTest]::State())"          # 修复前会停在屏幕顶部（y=0），修复后应已回到任务栏
```
</details>

## 截图 / 录屏
<img width="380" height="60" alt="taskbar-lyric-drift-to-top" src="https://github.com/user-attachments/assets/2762e161-ead6-4c9c-bda0-21c4bb1bbd5b" />


## 自查清单

- [x] 本 PR 只包含**一个主要功能 / 修复**，没有夹带无关改动
- [x] 已在本地**完整测试**通过；**AI 生成的代码同样自行测试并审阅过**，未做未经验证的提交
- [x] 已运行 `pnpm format`，并确认 `pnpm typecheck`、`pnpm lint` 通过
- [x] 改动涉及原生模块时已 `pnpm build:native` 验证；未手写 `native/*/index.d.ts`
- [x] 已向 `dev` 分支提交